### PR TITLE
Expose PublicKey in useWallet React Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2025-09-15
+
+### Changes
+
+* Expose account `publicKey` via `useWallet()` react hook
+
 ## 2025-09-12
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "publish": "node util/publish.js"
   },
   "devDependencies": {
-    "@demox-labs/miden-sdk": "0.11.5",
+    "@demox-labs/miden-sdk": "0.11.6",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-wallet-adapter",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/adapter.ts
+++ b/packages/core/base/adapter.ts
@@ -28,6 +28,7 @@ export interface WalletAdapterProps<Name extends string = string> {
   icon: string;
   readyState: WalletReadyState;
   accountId: string | null;
+  publicKey: Uint8Array | null;
   connecting: boolean;
   connected: boolean;
   supportedTransactionVersions: SupportedTransactionVersions;
@@ -81,6 +82,7 @@ export abstract class BaseWalletAdapter<Name extends string = string>
   abstract icon: string;
   abstract readyState: WalletReadyState;
   abstract accountId: string | null;
+  abstract publicKey: Uint8Array | null;
   abstract connecting: boolean;
   abstract supportedTransactionVersions: SupportedTransactionVersions;
 

--- a/packages/core/base/docs/classes/BaseMessageSignerWalletAdapter.md
+++ b/packages/core/base/docs/classes/BaseMessageSignerWalletAdapter.md
@@ -95,6 +95,20 @@ Minimal `EventEmitter` interface that is molded against the Node.js
 
 ***
 
+### publicKey
+
+> `abstract` **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+#### Implementation of
+
+`MessageSignerWalletAdapter.publicKey`
+
+#### Inherited from
+
+[`BaseSignerWalletAdapter`](BaseSignerWalletAdapter.md).[`publicKey`](BaseSignerWalletAdapter.md#publickey)
+
+***
+
 ### readyState
 
 > `abstract` **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/docs/classes/BaseSignerWalletAdapter.md
+++ b/packages/core/base/docs/classes/BaseSignerWalletAdapter.md
@@ -99,6 +99,20 @@ Minimal `EventEmitter` interface that is molded against the Node.js
 
 ***
 
+### publicKey
+
+> `abstract` **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+#### Implementation of
+
+`SignerWalletAdapter.publicKey`
+
+#### Inherited from
+
+[`BaseWalletAdapter`](BaseWalletAdapter.md).[`publicKey`](BaseWalletAdapter.md#publickey)
+
+***
+
 ### readyState
 
 > `abstract` **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/docs/classes/BaseWalletAdapter.md
+++ b/packages/core/base/docs/classes/BaseWalletAdapter.md
@@ -83,6 +83,16 @@ Minimal `EventEmitter` interface that is molded against the Node.js
 
 ***
 
+### publicKey
+
+> `abstract` **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+#### Implementation of
+
+`WalletAdapter.publicKey`
+
+***
+
 ### readyState
 
 > `abstract` **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/docs/interfaces/MessageSignerWalletAdapterProps.md
+++ b/packages/core/base/docs/interfaces/MessageSignerWalletAdapterProps.md
@@ -68,6 +68,16 @@
 
 ***
 
+### publicKey
+
+> **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+#### Inherited from
+
+[`WalletAdapterProps`](WalletAdapterProps.md).[`publicKey`](WalletAdapterProps.md#publickey)
+
+***
+
 ### readyState
 
 > **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/docs/interfaces/SignerWalletAdapterProps.md
+++ b/packages/core/base/docs/interfaces/SignerWalletAdapterProps.md
@@ -68,6 +68,16 @@
 
 ***
 
+### publicKey
+
+> **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+#### Inherited from
+
+[`WalletAdapterProps`](WalletAdapterProps.md).[`publicKey`](WalletAdapterProps.md#publickey)
+
+***
+
 ### readyState
 
 > **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/docs/interfaces/WalletAdapterProps.md
+++ b/packages/core/base/docs/interfaces/WalletAdapterProps.md
@@ -49,6 +49,12 @@
 
 ***
 
+### publicKey
+
+> **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+***
+
 ### readyState
 
 > **readyState**: [`WalletReadyState`](../enumerations/WalletReadyState.md)

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-wallet-adapter-base",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/WalletProvider.tsx
+++ b/packages/core/react/WalletProvider.tsx
@@ -39,11 +39,13 @@ const initialState: {
   wallet: Wallet | null;
   adapter: Adapter | null;
   accountId: string | null;
+  publicKey: Uint8Array | null;
   connected: boolean;
 } = {
   wallet: null,
   adapter: null,
   accountId: null,
+  publicKey: null,
   connected: false,
 };
 
@@ -61,7 +63,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     localStorageKey,
     null
   );
-  const [{ wallet, adapter, accountId, connected }, setState] =
+  const [{ wallet, adapter, accountId, publicKey, connected }, setState] =
     useState(initialState);
   const readyState = adapter?.readyState || WalletReadyState.Unsupported;
   const [connecting, setConnecting] = useState(false);
@@ -132,6 +134,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         adapter: wallet.adapter,
         connected: wallet.adapter.connected,
         accountId: wallet.adapter.accountId,
+        publicKey: wallet.adapter.publicKey
       });
     } else {
       setState(initialState);
@@ -155,6 +158,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
       ...state,
       connected: adapter.connected,
       accountId: adapter.accountId,
+      publicKey: adapter.publicKey
     }));
   }, [adapter]);
 
@@ -337,6 +341,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         wallets,
         wallet,
         accountId,
+        publicKey,
         connected,
         connecting,
         disconnecting,

--- a/packages/core/react/docs/interfaces/WalletContextState.md
+++ b/packages/core/react/docs/interfaces/WalletContextState.md
@@ -44,6 +44,12 @@
 
 ***
 
+### publicKey
+
+> **publicKey**: `Uint8Array`\<`ArrayBufferLike`\>
+
+***
+
 ### requestPrivateNotes()
 
 > **requestPrivateNotes**: () => `Promise`\<`any`[]\>

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-wallet-adapter-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/useWallet.ts
+++ b/packages/core/react/useWallet.ts
@@ -20,6 +20,7 @@ export interface WalletContextState {
   wallets: Wallet[];
   wallet: Wallet | null;
   accountId: string | null;
+  publicKey: Uint8Array | null;
   connecting: boolean;
   connected: boolean;
   disconnecting: boolean;
@@ -107,6 +108,12 @@ Object.defineProperty(DEFAULT_CONTEXT, 'wallet', {
 Object.defineProperty(DEFAULT_CONTEXT, 'accountId', {
   get() {
     console.error(constructMissingProviderErrorMessage('read', 'accountId'));
+    return null;
+  },
+});
+Object.defineProperty(DEFAULT_CONTEXT, 'publicKey', {
+  get() {
+    console.error(constructMissingProviderErrorMessage('read', 'publicKey'));
     return null;
   },
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-wallet-adapter-reactui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/adapter.ts
+++ b/packages/wallets/miden/adapter.ts
@@ -25,6 +25,7 @@ export interface MidenWalletEvents {
 
 export interface MidenWallet extends EventEmitter<MidenWalletEvents> {
   accountId?: string;
+  publicKey?: Uint8Array;
   requestSend(
     transaction: MidenSendTransaction
   ): Promise<{ transactionId?: string }>;
@@ -72,6 +73,7 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
   private _connecting: boolean;
   private _wallet: MidenWallet | null;
   private _accountId: string | null;
+  private _publicKey: Uint8Array | null;
   private _privateDataPermission: string;
   private _readyState: WalletReadyState =
     typeof window === 'undefined' || typeof document === 'undefined'
@@ -83,6 +85,7 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
     this._connecting = false;
     this._wallet = null;
     this._accountId = null;
+    this._publicKey = null;
     this._privateDataPermission = PrivateDataPermission.UponRequest;
 
     if (this._readyState !== WalletReadyState.Unsupported) {
@@ -99,6 +102,10 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
 
   get accountId() {
     return this._accountId;
+  }
+
+  get publicKey() {
+    return this._publicKey;
   }
 
   get privateDataPermission() {
@@ -220,6 +227,7 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
           throw new WalletConnectionError();
         }
         this._accountId = wallet.accountId!;
+        this._publicKey = wallet.publicKey!;
       } catch (error: any) {
         throw new WalletConnectionError(error?.message, error);
       }
@@ -243,6 +251,7 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
 
       this._wallet = null;
       this._accountId = null;
+      this._publicKey = null;
 
       try {
         await wallet.disconnect();

--- a/packages/wallets/miden/docs/classes/MidenWalletAdapter.md
+++ b/packages/wallets/miden/docs/classes/MidenWalletAdapter.md
@@ -142,6 +142,22 @@
 
 ***
 
+### publicKey
+
+#### Get Signature
+
+> **get** **publicKey**(): `Uint8Array`\<`ArrayBufferLike`\>
+
+##### Returns
+
+`Uint8Array`\<`ArrayBufferLike`\>
+
+#### Overrides
+
+`BaseMessageSignerWalletAdapter.publicKey`
+
+***
+
 ### readyState
 
 #### Get Signature

--- a/packages/wallets/miden/docs/interfaces/MidenWallet.md
+++ b/packages/wallets/miden/docs/interfaces/MidenWallet.md
@@ -16,6 +16,12 @@
 
 > `optional` **accountId**: `string`
 
+***
+
+### publicKey?
+
+> `optional` **publicKey**: `Uint8Array`
+
 ## Methods
 
 ### addListener()

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demox-labs/miden-wallet-adapter-miden",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@demox-labs/miden-sdk@npm:0.11.5":
-  version: 0.11.5
-  resolution: "@demox-labs/miden-sdk@npm:0.11.5"
+"@demox-labs/miden-sdk@npm:0.11.6":
+  version: 0.11.6
+  resolution: "@demox-labs/miden-sdk@npm:0.11.6"
   dependencies:
     chai-as-promised: "npm:^8.0.0"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
-  checksum: 10c0/21c0dad0f33138693fc95c67b775c01d454f8f1d15a71ddecb60fcfca02fee507737c54519290446e9bc413cf1486ed710e7416c3247ba72100f85b1f78ac9e4
+  checksum: 10c0/b1b216734fff12906958743870dbe40138fb08d9e7653e487572b3ff694f38bf11fc3fc79ddcf9dd93bb466cfc555cf4214f6842e8b63a373c63ec44660bc19d
   languageName: node
   linkType: hard
 
@@ -1291,7 +1291,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miden-wallet-adapter@workspace:."
   dependencies:
-    "@demox-labs/miden-sdk": "npm:0.11.5"
+    "@demox-labs/miden-sdk": "npm:0.11.6"
     "@types/node": "npm:^22.13.5"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.0.4"


### PR DESCRIPTION
Sign workflow is done, but public key exposed via the `useWallet()` hook is needed to verify the signatures.