### PR TITLE
fix: Do not autoconnect as default, bump to 0.13.5

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -88,7 +88,7 @@ export interface MidenFiSignerProviderProps {
   appName?: string;
   /** Network to connect to */
   network?: WalletAdapterNetwork;
-  /** Auto-connect to previously selected wallet on mount. Defaults to true */
+  /** Auto-connect to previously selected wallet on mount. Defaults to false */
   autoConnect?: boolean;
   /** Private data permission level */
   privateDataPermission?: PrivateDataPermission;
@@ -171,7 +171,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
   wallets: walletsProp,
   appName = 'Miden DApp',
   network = WalletAdapterNetwork.Testnet,
-  autoConnect = true,
+  autoConnect = false,
   privateDataPermission = PrivateDataPermission.UponRequest,
   allowedPrivateData = AllowedPrivateData.None,
   onError,
@@ -603,8 +603,8 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
     storeName: '',
     name: 'MidenFi',
     isConnected: false,
-    connect: connectRef.current,
-    disconnect: disconnectRef.current,
+    connect: async () => { await connectRef.current(); },
+    disconnect: async () => { await disconnectRef.current(); },
   });
 
   // The connected context ref — reused across renders to maintain referential identity.

--- a/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
+++ b/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
@@ -289,24 +289,24 @@ describe('MidenFiSignerProvider', () => {
       expect(typeof result.current.select).toBe('function');
     });
 
-    it('autoConnect defaults to true', () => {
+    it('autoConnect defaults to false', () => {
       const { result } = renderHook(() => useMidenFiWallet(), {
         wrapper: ({ children }) => (
           <MidenFiSignerProvider>{children}</MidenFiSignerProvider>
         ),
       });
 
-      expect(result.current.autoConnect).toBe(true);
+      expect(result.current.autoConnect).toBe(false);
     });
 
-    it('autoConnect can be set to false', () => {
+    it('autoConnect can be set to true', () => {
       const { result } = renderHook(() => useMidenFiWallet(), {
         wrapper: ({ children }) => (
-          <MidenFiSignerProvider autoConnect={false}>{children}</MidenFiSignerProvider>
+          <MidenFiSignerProvider autoConnect={true}>{children}</MidenFiSignerProvider>
         ),
       });
 
-      expect(result.current.autoConnect).toBe(false);
+      expect(result.current.autoConnect).toBe(true);
     });
 
     it('exposes createAccount from adapter', () => {

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Disable autoconnect by default to prevent unwanted automatic wallet connections
- Bump all package versions to 0.13.5