### PR TITLE
chore: migrate to 0.14.0

### DIFF
--- a/examples/discover-miden/package.json
+++ b/examples/discover-miden/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.13.1",
+    "@miden-sdk/miden-sdk": "^0.14.0",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",

--- a/examples/react-signer/package.json
+++ b/examples/react-signer/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.13.1",
+    "@miden-sdk/miden-sdk": "^0.14.0",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",
-    "@miden-sdk/react": "^0.13.3",
+    "@miden-sdk/react": "^0.14.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "publish": "node util/publish.js"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "0.13.0",
+    "@miden-sdk/miden-sdk": "0.14.0",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
@@ -35,6 +35,6 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@miden-sdk/miden-sdk": "0.13.0"
+    "@miden-sdk/miden-sdk": "0.14.0"
   }
 }

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -104,6 +104,8 @@ export interface MidenFiSignerProviderProps {
   storageMode?: 'private' | 'public' | 'network';
   /** Custom account components to include in the account (e.g. from a compiled .masp package) */
   customComponents?: AccountComponent[];
+  /** Existing account ID to import instead of creating a new account */
+  importAccountId?: string;
 }
 
 const initialState: {
@@ -179,6 +181,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
   accountType = 'RegularAccountImmutableCode',
   storageMode = 'public',
   customComponents,
+  importAccountId,
 }) => {
   // Create default wallets if not provided
   const adapters = useMemo(
@@ -645,6 +648,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
               accountType,
               storageMode: resolvedStorageMode,
               ...(customComponents?.length ? { customComponents } : {}),
+              ...(importAccountId ? { importAccountId } : {}),
             },
             storeName: `midenfi_${address}`,
             name: 'MidenFi',
@@ -669,7 +673,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [connected, publicKey, address, accountType, storageMode, customComponents]);
+  }, [connected, publicKey, address, accountType, storageMode, customComponents, importAccountId]);
 
   const walletContextValue = useMemo(
     () => ({

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,8 @@
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "^0.13.1",
-    "@miden-sdk/react": "^0.13.3",
+    "@miden-sdk/miden-sdk": "^0.14.0",
+    "@miden-sdk/react": "^0.14.0",
     "@testing-library/react": "^14.0.0",
     "jsdom": "^24.0.0",
     "react": "^19.1.1",
@@ -31,7 +31,7 @@
     "vitest": "^1.0.0"
   },
   "peerDependencies": {
-    "@miden-sdk/react": "^0.13.3",
+    "@miden-sdk/react": "^0.14.0",
     "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,25 +732,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miden-sdk/miden-sdk@npm:0.13.0":
-  version: 0.13.0
-  resolution: "@miden-sdk/miden-sdk@npm:0.13.0"
+"@miden-sdk/miden-sdk@npm:0.14.0, @miden-sdk/miden-sdk@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@miden-sdk/miden-sdk@npm:0.14.0"
   dependencies:
     "@rollup/plugin-typescript": "npm:^12.3.0"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
-  checksum: 10c0/13c5e5ac38ed69bd7d6399deda776b678670757fe10a3eb3f583155a18d19a29a63c161d470c7cdf9d4104c04af38f67d2e276f9d6f563be0dce2a9fd7be1e1c
-  languageName: node
-  linkType: hard
-
-"@miden-sdk/miden-sdk@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "@miden-sdk/miden-sdk@npm:0.13.1"
-  dependencies:
-    "@rollup/plugin-typescript": "npm:^12.3.0"
-    dexie: "npm:^4.0.1"
-    glob: "npm:^11.0.0"
-  checksum: 10c0/98c0ea691c1cc6544eb907ed3ee2758167d7dcd4f20d33e757ba9416eb8d6c73e59a0df03c466aa8a2dd63832364a9e85958ea47bb38d632185beed289cdadf7
+  checksum: 10c0/0232f6d1c59b41f26b39737f460dea5dfe99ee9e8772dcce8dee961fc4fcdc9ffd7f529cd351f3f9667fc3a976b9d8ef7f80faef3d756edf0fc92a7d35ebd57c
   languageName: node
   linkType: hard
 
@@ -781,17 +770,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miden-sdk/miden-wallet-adapter-react@workspace:packages/core/react"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.13.1"
+    "@miden-sdk/miden-sdk": "npm:^0.14.0"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
-    "@miden-sdk/react": "npm:^0.13.3"
+    "@miden-sdk/react": "npm:^0.14.0"
     "@testing-library/react": "npm:^14.0.0"
     jsdom: "npm:^24.0.0"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
     vitest: "npm:^1.0.0"
   peerDependencies:
-    "@miden-sdk/react": ^0.13.3
+    "@miden-sdk/react": ^0.14.0
     react: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@miden-sdk/react":
@@ -837,15 +826,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@miden-sdk/react@npm:^0.13.3":
-  version: 0.13.3
-  resolution: "@miden-sdk/react@npm:0.13.3"
+"@miden-sdk/react@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@miden-sdk/react@npm:0.14.0"
   dependencies:
     zustand: "npm:^5.0.0"
   peerDependencies:
-    "@miden-sdk/miden-sdk": ^0.13.0
+    "@miden-sdk/miden-sdk": ^0.14.0
     react: ">=18.0.0"
-  checksum: 10c0/7720b5656172d371c97e7728653790efcd8a1759d12161eea355ab9e164f2d75838816722b97f647a097d27a8c3b84b06924a4dd2bba1f7af191f0e9b236fb59
+  checksum: 10c0/96d7cdd351cf5e577c3b183166f3f5b15aebeefdccd50e09d30a2463444747c9d9e514aadfeeea9fc809993e82e95fa05db7d74ffdc816c4a9f2e208c5821c2b
   languageName: node
   linkType: hard
 
@@ -2317,7 +2306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "discover-miden-example@workspace:examples/discover-miden"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.13.1"
+    "@miden-sdk/miden-sdk": "npm:^0.14.0"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
@@ -3638,7 +3627,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miden-wallet-adapter@workspace:."
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:0.13.0"
+    "@miden-sdk/miden-sdk": "npm:0.14.0"
     "@types/node": "npm:^22.13.5"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.0.4"
@@ -3647,7 +3636,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:^4.4.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@miden-sdk/miden-sdk": 0.13.0
+    "@miden-sdk/miden-sdk": 0.14.0
   languageName: unknown
   linkType: soft
 
@@ -4422,11 +4411,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-signer-example@workspace:examples/react-signer"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.13.1"
+    "@miden-sdk/miden-sdk": "npm:^0.14.0"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
-    "@miden-sdk/react": "npm:^0.13.3"
+    "@miden-sdk/react": "npm:^0.14.0"
     "@types/react": "npm:^19.2.0"
     "@types/react-dom": "npm:^19.2.0"
     "@vitejs/plugin-react": "npm:^5.1.1"


### PR DESCRIPTION
## Summary
- Bump all workspace package versions from 0.13.6 → 0.14.0
- Bump `@miden-sdk/miden-sdk` and `@miden-sdk/react` dependencies to ^0.14.0
- Add optional `importAccountId` prop to `MidenFiSignerProvider` for parity with Para/Turnkey providers