### PR TITLE
fix: correct requestSend API usage and arrow function syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ function SendComponent() {
     );
 
     try {
-      await wallet.adapter.requestSend(transaction);
+      await (wallet.adapter as MidenWalletAdapter).requestSend(transaction);
       console.log('Transaction sent successfully!');
     } catch (error) {
       console.error('Transaction failed:', error);
@@ -128,7 +128,7 @@ import { useWallet } from '@miden-sdk/miden-wallet-adapter';
 function AssetsAndNotesComponent() {
   const { wallet, address, requestAssets, requestPrivateNotes } = useWallet();
 
-  const getAssetsAndNotes() = async () => {
+  const getAssetsAndNotes = async () => {
     if (!wallet || !address) return;
 
     // { faucetId: string, amount: string }[]


### PR DESCRIPTION
## Issues Fixed

### 1. Incorrect `requestSend` API usage
The README Send Transaction example calls:
```typescript
await wallet.adapter.requestSend(transaction);
```
But `requestSend` is not directly available on `wallet.adapter` — 
TypeScript reports it as unavailable without an explicit cast. 

Fixed by casting to `MidenWalletAdapter` as required:
```typescript
await (wallet.adapter as MidenWalletAdapter).requestSend(transaction);
```

This was reported in: https://github.com/0xMiden/feedback/issues/93

### 2. Broken arrow function syntax
The `getAssetsAndNotes` function had incorrect syntax:
```typescript
const getAssetsAndNotes() = async () => {
```
Fixed to:
```typescript
const getAssetsAndNotes = async () => {
```

## Impact
Both issues would cause confusion and errors for developers 
following the README examples to integrate the wallet adapter.