### PR TITLE
feat: add Devnet to WalletAdapterNetwork, bump to 0.14.1

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/types.ts
+++ b/packages/core/base/types.ts
@@ -1,6 +1,7 @@
 import type { InputNoteState, Note, NoteType } from '@miden-sdk/miden-sdk';
 
 export enum WalletAdapterNetwork {
+  Devnet = 'devnet',
   Testnet = 'testnet',
   Localnet = 'localnet',
 }

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Closes #78.

## Summary

- Adds `Devnet = 'devnet'` to the `WalletAdapterNetwork` enum in `@miden-sdk/miden-wallet-adapter-base`.
- Bumps all five workspace packages `0.14.0` → `0.14.1`.

## Why

The enum was missing `Devnet`, so dApps targeting devnet had to pass `WalletAdapterNetwork.Testnet` to `MidenFiSignerProvider` while simultaneously configuring `MidenProvider` with `rpcUrl: 'devnet'`. Confusing and inaccurate.

`examples/react-signer/src/main.tsx` already references `WalletAdapterNetwork.Devnet` — prior to this change it wouldn't compile.

## MidenFi wallet extension

The issue also mentions the extension should accept `'devnet'` in its connect protocol. Verified no changes are needed on the extension side: its `NETWORKS` registry already includes devnet, `getNetworkRPC('devnet')` resolves correctly, and `isAllowedNetwork()` is a pass-through. The string flows through the bridge as JSON and is looked up at runtime.

## Test plan

- [x] `yarn build` — clean across all workspaces
- [x] `yarn test` — 148 tests pass (base + react + wallets/miden)
- [x] `examples/react-signer` now compiles with `WalletAdapterNetwork.Devnet`