### PR TITLE
chore: bump miden-sdk to 0.14.4, version to 0.14.2

### DIFF
--- a/examples/discover-miden/package.json
+++ b/examples/discover-miden/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.0",
+    "@miden-sdk/miden-sdk": "^0.14.4",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",

--- a/examples/react-signer/package.json
+++ b/examples/react-signer/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.0",
+    "@miden-sdk/miden-sdk": "^0.14.4",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",
-    "@miden-sdk/react": "^0.14.0",
+    "@miden-sdk/react": "^0.14.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "publish": "node util/publish.js"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "0.14.0",
+    "@miden-sdk/miden-sdk": "0.14.4",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
@@ -35,6 +35,6 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@miden-sdk/miden-sdk": "0.14.0"
+    "@miden-sdk/miden-sdk": "0.14.4"
   }
 }

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,8 @@
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "^0.14.0",
-    "@miden-sdk/react": "^0.14.0",
+    "@miden-sdk/miden-sdk": "^0.14.4",
+    "@miden-sdk/react": "^0.14.4",
     "@testing-library/react": "^14.0.0",
     "jsdom": "^24.0.0",
     "react": "^19.1.1",
@@ -31,7 +31,7 @@
     "vitest": "^1.0.0"
   },
   "peerDependencies": {
-    "@miden-sdk/react": "^0.14.0",
+    "@miden-sdk/react": "^0.14.4",
     "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,14 +732,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miden-sdk/miden-sdk@npm:0.14.0, @miden-sdk/miden-sdk@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@miden-sdk/miden-sdk@npm:0.14.0"
+"@miden-sdk/miden-sdk@npm:0.14.4, @miden-sdk/miden-sdk@npm:^0.14.4":
+  version: 0.14.4
+  resolution: "@miden-sdk/miden-sdk@npm:0.14.4"
   dependencies:
     "@rollup/plugin-typescript": "npm:^12.3.0"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
-  checksum: 10c0/0232f6d1c59b41f26b39737f460dea5dfe99ee9e8772dcce8dee961fc4fcdc9ffd7f529cd351f3f9667fc3a976b9d8ef7f80faef3d756edf0fc92a7d35ebd57c
+  checksum: 10c0/0eb292b680665a1019cec8531518a96c9e5389acd6b99a18487e2a8167374ca9c858da36bf49d9222e6bfa0b6c35dc38414daa9ddb7ee59e1b27f3abd762ce22
   languageName: node
   linkType: hard
 
@@ -770,17 +770,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miden-sdk/miden-wallet-adapter-react@workspace:packages/core/react"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.14.0"
+    "@miden-sdk/miden-sdk": "npm:^0.14.4"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
-    "@miden-sdk/react": "npm:^0.14.0"
+    "@miden-sdk/react": "npm:^0.14.4"
     "@testing-library/react": "npm:^14.0.0"
     jsdom: "npm:^24.0.0"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
     vitest: "npm:^1.0.0"
   peerDependencies:
-    "@miden-sdk/react": ^0.14.0
+    "@miden-sdk/react": ^0.14.4
     react: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@miden-sdk/react":
@@ -826,15 +826,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@miden-sdk/react@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@miden-sdk/react@npm:0.14.0"
+"@miden-sdk/react@npm:^0.14.4":
+  version: 0.14.4
+  resolution: "@miden-sdk/react@npm:0.14.4"
   dependencies:
     zustand: "npm:^5.0.0"
   peerDependencies:
-    "@miden-sdk/miden-sdk": ^0.14.0
+    "@miden-sdk/miden-sdk": ^0.14.4
     react: ">=18.0.0"
-  checksum: 10c0/96d7cdd351cf5e577c3b183166f3f5b15aebeefdccd50e09d30a2463444747c9d9e514aadfeeea9fc809993e82e95fa05db7d74ffdc816c4a9f2e208c5821c2b
+  checksum: 10c0/503a4631361e0b8d1737665373b988fabb7eec77957673cc739fd20d5b58e89815fb1445c248a22237352da9f15d9393fd14448c5289199746420a8c8be00325
   languageName: node
   linkType: hard
 
@@ -2306,7 +2306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "discover-miden-example@workspace:examples/discover-miden"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.14.0"
+    "@miden-sdk/miden-sdk": "npm:^0.14.4"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
@@ -3627,7 +3627,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miden-wallet-adapter@workspace:."
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:0.14.0"
+    "@miden-sdk/miden-sdk": "npm:0.14.4"
     "@types/node": "npm:^22.13.5"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.0.4"
@@ -3636,7 +3636,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:^4.4.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@miden-sdk/miden-sdk": 0.14.0
+    "@miden-sdk/miden-sdk": 0.14.4
   languageName: unknown
   linkType: soft
 
@@ -4411,11 +4411,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-signer-example@workspace:examples/react-signer"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.14.0"
+    "@miden-sdk/miden-sdk": "npm:^0.14.4"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
-    "@miden-sdk/react": "npm:^0.14.0"
+    "@miden-sdk/react": "npm:^0.14.4"
     "@types/react": "npm:^19.2.0"
     "@types/react-dom": "npm:^19.2.0"
     "@vitejs/plugin-react": "npm:^5.1.1"


### PR DESCRIPTION
## Summary
- Upgrade `@miden-sdk/miden-sdk` and `@miden-sdk/react` from `0.14.0` to `0.14.4`.
- Bump workspace package versions from `0.14.1` to `0.14.2`.

## Test plan
- [ ] `yarn install` to refresh the lockfile
- [ ] `yarn build`
- [ ] `yarn test`