### PR TITLE
fix(react): import wallet's existing account instead of rebuilding locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-04-21
+
+### Fixes
+
+* `MidenFiSignerProvider` now always passes the wallet's `address` as `importAccountId` in the signer context's `accountConfig`, so `@miden-sdk/react`'s `initializeSignerAccount` takes the import-by-id branch instead of trying to rebuild the account from scratch locally. The rebuild path hits an `invalid enum value passed` error in `@miden-sdk/react` <= 0.14.4 (it reads `AuthScheme.AuthEcdsaK256Keccak`, which doesn't exist on the public `AuthScheme` constant — a client-side bug fixed in the unreleased 0.14.5). Importing by ID is also the semantically correct flow: the wallet already owns the account, and its bech32 address *is* the on-chain account ID. Consumers can still override via the `importAccountId` prop.
+
+### New Versions
+
+* `0.14.3` for all packages
+
 ## 2026-02-09
 
 ### Features

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -641,6 +641,14 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
 
           const resolvedStorageMode = AccountStorageMode.tryFromStr(storageMode);
 
+          // Always hand the wallet's existing account ID to `initializeSignerAccount`
+          // so it takes the import-by-id branch. The wallet already owns the account
+          // (the bech32 `address` IS the on-chain account ID); reconstructing it
+          // locally would require knowing every creation parameter the wallet used
+          // (seed, auth scheme, storage mode, components) and would also hit a
+          // broken `AuthScheme.AuthEcdsaK256Keccak` lookup in `@miden-sdk/react`
+          // <= 0.14.4. Consumers can still override by passing an explicit
+          // `importAccountId` prop (e.g. to pin to a non-default account).
           const ctx: SignerContextValue = {
             signCb,
             accountConfig: {
@@ -648,7 +656,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
               accountType,
               storageMode: resolvedStorageMode,
               ...(customComponents?.length ? { customComponents } : {}),
-              ...(importAccountId ? { importAccountId } : {}),
+              importAccountId: importAccountId ?? address,
             },
             storeName: `midenfi_${address}`,
             name: 'MidenFi',

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- `MidenFiSignerProvider` was handing an optional `importAccountId` to the signer context's `accountConfig` — undefined by default. When unset, `@miden-sdk/react`'s `initializeSignerAccount` takes the "rebuild account from scratch" branch, which (a) assumes the dApp knows every creation parameter the wallet used (seed, auth scheme, storage mode, components) and (b) hits a broken `AuthScheme.AuthEcdsaK256Keccak` lookup on the public `AuthScheme` const in `@miden-sdk/react` ≤ 0.14.4, throwing `"invalid enum value passed"` at the wasm boundary.
- Always pass the wallet's bech32 `address` as `importAccountId` so the React SDK takes the import-by-id branch, which doesn't touch `AuthScheme` at all. This is also the semantically correct behavior — the wallet owns the account, and its address *is* the on-chain account ID. Consumers can still override via the `importAccountId` prop.
- Bumps all workspace packages `0.14.2` → `0.14.3`.

## Notes
- Self-contained fix: works against published `@miden-sdk/react@0.14.4`. No dependency on the upstream client fix (tracked separately in [0xMiden/miden-client#2088](https://github.com/0xMiden/miden-client/pull/2088)).
- `customComponents` is silently ignored when `importAccountId` is set — a pre-existing limitation of `initializeSignerAccount`'s import branch. Acceptable, since custom components can't be bolted onto an existing on-chain account anyway.

## Test plan
- [ ] `yarn build && yarn typecheck && yarn test` at repo root
- [ ] Run `examples/react-signer` against published `@miden-sdk/miden-sdk@0.14.4` + `@miden-sdk/react@0.14.4` (i.e. no local link of the unreleased 0.14.5), confirm `Miden Ready: Yes` after wallet connect and no `invalid enum value passed` in console
- [ ] Verify `useMidenFiWallet().address` still matches the Miden Ready account ID post-connect