### PR TITLE
fix(miden): dispatch requestTransaction by type so Consume/Send work (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* `MidenWalletAdapter.requestTransaction` now dispatches by `transaction.type`: `Send` transactions go to the wallet's `requestSend` endpoint and `Consume` transactions to `requestConsume`, while `Custom` (and bare/legacy payloads) continue through the generalized `requestTransaction` endpoint. The wallet's generalized endpoint only accepts a custom-transaction payload, so consuming a note via the typed `Transaction(TransactionType.Consume, new ConsumeTransaction(...))` API previously failed with `WalletTransactionError: INVALID_PARAMS: Invalid CustomTransaction payload`. Fixes [#88](https://github.com/0xMiden/wallet-adapter/issues/88).
+
 ## 2026-04-21
 
 ### Fixes

--- a/packages/wallets/miden/__tests__/adapter.test.ts
+++ b/packages/wallets/miden/__tests__/adapter.test.ts
@@ -195,9 +195,59 @@ describe('MidenWalletAdapter', () => {
       expect(result).toBe('tx-consume-1');
     });
 
-    it('requestTransaction delegates to wallet and returns transactionId', async () => {
+    it('requestTransaction routes a Consume transaction to wallet.requestConsume (issue #88)', async () => {
       const { adapter, mockWallet } = await createConnectedAdapter();
-      const tx = { type: 'send' as any, payload: {} as any };
+      const payload = {
+        faucetId: 'f',
+        noteId: 'n',
+        noteType: 'public' as const,
+        amount: 50,
+      };
+      const result = await adapter.requestTransaction({
+        type: 'consume' as any,
+        payload,
+      });
+      expect(mockWallet.requestConsume).toHaveBeenCalledWith(payload);
+      expect(mockWallet.requestTransaction).not.toHaveBeenCalled();
+      expect(result).toBe('tx-consume-1');
+    });
+
+    it('requestTransaction routes a Send transaction to wallet.requestSend', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      const payload = {
+        senderAddress: 's',
+        recipientAddress: 'r',
+        faucetId: 'f',
+        noteType: 'public' as const,
+        amount: 100,
+      };
+      const result = await adapter.requestTransaction({
+        type: 'send' as any,
+        payload,
+      });
+      expect(mockWallet.requestSend).toHaveBeenCalledWith(payload);
+      expect(mockWallet.requestTransaction).not.toHaveBeenCalled();
+      expect(result).toBe('tx-send-1');
+    });
+
+    it('requestTransaction forwards a Custom transaction to wallet.requestTransaction', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      const tx = {
+        type: 'custom' as any,
+        payload: {
+          address: 'addr',
+          recipientAddress: 'r',
+          transactionRequest: 'base64-request',
+        } as any,
+      };
+      const result = await adapter.requestTransaction(tx);
+      expect(mockWallet.requestTransaction).toHaveBeenCalledWith(tx);
+      expect(result).toBe('tx-custom-1');
+    });
+
+    it('requestTransaction forwards a bare (typeless) payload to wallet.requestTransaction', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      const tx = { address: 'addr', transactionRequest: 'base64-request' } as any;
       const result = await adapter.requestTransaction(tx);
       expect(mockWallet.requestTransaction).toHaveBeenCalledWith(tx);
       expect(result).toBe('tx-custom-1');

--- a/packages/wallets/miden/adapter.ts
+++ b/packages/wallets/miden/adapter.ts
@@ -16,6 +16,7 @@ import {
   MidenSendTransaction,
   MidenTransaction,
   MidenConsumeTransaction,
+  TransactionType,
   WalletTransactionError,
   Asset,
   CreateAccountParams,
@@ -180,7 +181,30 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
       const wallet = this._wallet;
       if (!wallet || !this.address) throw new WalletNotConnectedError();
       try {
-        const result = await wallet.requestTransaction(transaction);
+        // The wallet's generalized `requestTransaction` endpoint only accepts
+        // a custom-transaction payload, so a `send`/`consume` transaction must
+        // be routed to its dedicated endpoint — otherwise the wallet rejects
+        // it with "Invalid CustomTransaction payload". Dispatching by `type`
+        // here is what lets the typed `Transaction` / `TransactionType` API
+        // (incl. `Transaction.createConsumeTransaction`) work for every type.
+        let result: { transactionId?: string };
+        switch (transaction.type) {
+          case TransactionType.Send:
+            result = await wallet.requestSend(
+              transaction.payload as MidenSendTransaction
+            );
+            break;
+          case TransactionType.Consume:
+            result = await wallet.requestConsume(
+              transaction.payload as MidenConsumeTransaction
+            );
+            break;
+          default:
+            // Custom transactions — and legacy callers that pass a bare
+            // `CustomTransaction` payload — go through the generalized endpoint.
+            result = await wallet.requestTransaction(transaction);
+            break;
+        }
         return result.transactionId!;
       } catch (error: any) {
         throw new WalletTransactionError(error?.message, error);


### PR DESCRIPTION
Fixes #88.

## Problem

Consuming a note through the **generalized** transaction API:

```tsx
await requestTransaction(
  new Transaction(
    TransactionType.Consume,
    new ConsumeTransaction(faucetId, noteId, 'public', amount, note.serialize()),
  ),
);
```

throws:

```
WalletTransactionError: INVALID_PARAMS: Error: INVALID_PARAMS: Invalid CustomTransaction payload
```

even though the dedicated `requestConsume(...)` works fine.

## Root cause

`MidenWalletAdapter.requestTransaction` forwarded the `{ type, payload }` wrapper straight to the wallet's generalized `requestTransaction` endpoint:

```ts
const result = await wallet.requestTransaction(transaction);
```

That endpoint only accepts a **custom-transaction** payload — it validates whatever it receives as a `CustomTransaction` regardless of `type`. So a `consume` (or `send`) payload is rejected with *"Invalid CustomTransaction payload"*. The typed `Transaction` / `TransactionType` union and the `Transaction.createConsumeTransaction` / `createSendTransaction` factories imply the generalized entry point should work for every type, but nothing dispatched on `type`.

## Fix

Dispatch by `transaction.type` in the adapter, routing to the endpoints that actually handle each shape:

| `type` | routed to |
|---|---|
| `Send` | `wallet.requestSend(payload)` |
| `Consume` | `wallet.requestConsume(payload)` |
| `Custom` / bare payload (default) | `wallet.requestTransaction(transaction)` |

`Send`/`Consume` now use the same dedicated endpoints the standalone `adapter.requestConsume` / `requestSend` already use (and which the issue confirms work). `Custom` and bare/legacy payloads (the README's `requestTransaction(new CustomTransaction(...))` usage) keep flowing through the generalized endpoint, so nothing regresses.

## Tests

`packages/wallets/miden/__tests__/adapter.test.ts` now covers all four routes:
- Consume → `wallet.requestConsume` (and asserts the generalized endpoint is **not** called)
- Send → `wallet.requestSend`
- Custom → `wallet.requestTransaction`
- bare/typeless payload → `wallet.requestTransaction`

## Verification

- `yarn test` (all workspaces): **151 passed** (base 93, react 23, miden 35).
- `tsc` typecheck/build of `@miden-sdk/miden-wallet-adapter-base` and `@miden-sdk/miden-wallet-adapter-miden`: clean.
- Lockfile untouched, so `yarn install --immutable` (the other CI step) stays green.

## Note

The deeper cause is that the wallet's generalized `requestTransaction` handler doesn't branch on `type` (its declared signature takes a full `MidenTransaction`, so arguably it should). This adapter-side dispatch fixes the consumer-visible bug immediately using endpoints already known to work; if the wallet's generalized handler is later taught to dispatch by type, this routing remains correct and harmless.