### PR TITLE
chore: bump miden SDK to 0.15.1

### DIFF
--- a/examples/discover-miden/package.json
+++ b/examples/discover-miden/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",

--- a/examples/react-signer/package.json
+++ b/examples/react-signer/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@miden-sdk/miden-sdk": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^",
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/react": "^0.15.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "publish": "node util/publish.js"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "0.15.0",
+    "@miden-sdk/miden-sdk": "0.15.1",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
@@ -35,6 +35,6 @@
     "typescript": "^5.7.2"
   },
   "peerDependencies": {
-    "@miden-sdk/miden-sdk": "0.15.0"
+    "@miden-sdk/miden-sdk": "0.15.1"
   }
 }

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -22,8 +22,8 @@
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
   },
   "devDependencies": {
-    "@miden-sdk/miden-sdk": "^0.15.0",
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/miden-sdk": "^0.15.1",
+    "@miden-sdk/react": "^0.15.1",
     "@testing-library/react": "^14.0.0",
     "jsdom": "^24.0.0",
     "react": "^19.1.1",
@@ -31,7 +31,7 @@
     "vitest": "^1.0.0"
   },
   "peerDependencies": {
-    "@miden-sdk/react": "^0.15.0",
+    "@miden-sdk/react": "^0.15.1",
     "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -732,13 +732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@miden-sdk/miden-sdk@npm:0.15.0, @miden-sdk/miden-sdk@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/miden-sdk@npm:0.15.0"
+"@miden-sdk/miden-sdk@npm:0.15.1, @miden-sdk/miden-sdk@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/miden-sdk@npm:0.15.1"
   dependencies:
-    "@miden-sdk/node-darwin-arm64": "npm:0.15.0"
-    "@miden-sdk/node-darwin-x64": "npm:0.15.0"
-    "@miden-sdk/node-linux-x64-gnu": "npm:0.15.0"
+    "@miden-sdk/node-darwin-arm64": "npm:0.15.1"
+    "@miden-sdk/node-darwin-x64": "npm:0.15.1"
+    "@miden-sdk/node-linux-x64-gnu": "npm:0.15.1"
     dexie: "npm:^4.0.1"
     glob: "npm:^11.0.0"
   dependenciesMeta:
@@ -748,7 +748,7 @@ __metadata:
       optional: true
     "@miden-sdk/node-linux-x64-gnu":
       optional: true
-  checksum: 10c0/94b1849c584c5480893ab368dc491e1b73487c89551324fc57fd0eba15287802a8581e3ebaf1ebd8ea66ffc3387ba88703ddb3a8621d1de3bbf4df1d9b5a108e
+  checksum: 10c0/6ace9a5da79df693e32f874adcb011d1dda927a8bafe3cbb65d725e9a17df3106b24b3d21dcd60e10274e13633c9fca08d42ba757e3abac4c598c1c8119dd143
   languageName: node
   linkType: hard
 
@@ -779,17 +779,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miden-sdk/miden-wallet-adapter-react@workspace:packages/core/react"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.15.0"
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
-    "@miden-sdk/react": "npm:^0.15.0"
+    "@miden-sdk/react": "npm:^0.15.1"
     "@testing-library/react": "npm:^14.0.0"
     jsdom: "npm:^24.0.0"
     react: "npm:^19.1.1"
     react-dom: "npm:^19.1.1"
     vitest: "npm:^1.0.0"
   peerDependencies:
-    "@miden-sdk/react": ^0.15.0
+    "@miden-sdk/react": ^0.15.1
     react: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@miden-sdk/react":
@@ -835,36 +835,36 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@miden-sdk/node-darwin-arm64@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-darwin-arm64@npm:0.15.0"
+"@miden-sdk/node-darwin-arm64@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-darwin-arm64@npm:0.15.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@miden-sdk/node-darwin-x64@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-darwin-x64@npm:0.15.0"
+"@miden-sdk/node-darwin-x64@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-darwin-x64@npm:0.15.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@miden-sdk/node-linux-x64-gnu@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/node-linux-x64-gnu@npm:0.15.0"
+"@miden-sdk/node-linux-x64-gnu@npm:0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/node-linux-x64-gnu@npm:0.15.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@miden-sdk/react@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@miden-sdk/react@npm:0.15.0"
+"@miden-sdk/react@npm:^0.15.1":
+  version: 0.15.1
+  resolution: "@miden-sdk/react@npm:0.15.1"
   dependencies:
     zustand: "npm:^5.0.0"
   peerDependencies:
-    "@miden-sdk/miden-sdk": ^0.15.0
+    "@miden-sdk/miden-sdk": ^0.15.1
     react: ">=18.0.0"
-  checksum: 10c0/1e9673785547b06d9a68de7fa72cf11bfd05045d19eae90df4cf9350ef38e29795478883bd9aaef78a0866e87682d1e5b48cff15c1537550d398b6d25e3a585f
+  checksum: 10c0/a09e3cb81e8e196be18ffd0ff6620d4dd6a24910bdc9f32166e162b9966cf0518232426799f543021b657fd063130374e6178548cc434e2fbf49f7c3ad11e5f2
   languageName: node
   linkType: hard
 
@@ -2317,7 +2317,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "discover-miden-example@workspace:examples/discover-miden"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.15.0"
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
@@ -3638,7 +3638,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miden-wallet-adapter@workspace:."
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:0.15.0"
+    "@miden-sdk/miden-sdk": "npm:0.15.1"
     "@types/node": "npm:^22.13.5"
     "@types/react": "npm:^19.0.10"
     "@types/react-dom": "npm:^19.0.4"
@@ -3647,7 +3647,7 @@ __metadata:
     typedoc-plugin-markdown: "npm:^4.4.1"
     typescript: "npm:^5.7.2"
   peerDependencies:
-    "@miden-sdk/miden-sdk": 0.15.0
+    "@miden-sdk/miden-sdk": 0.15.1
   languageName: unknown
   linkType: soft
 
@@ -4422,11 +4422,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-signer-example@workspace:examples/react-signer"
   dependencies:
-    "@miden-sdk/miden-sdk": "npm:^0.15.0"
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-miden": "workspace:^"
     "@miden-sdk/miden-wallet-adapter-react": "workspace:^"
-    "@miden-sdk/react": "npm:^0.15.0"
+    "@miden-sdk/react": "npm:^0.15.1"
     "@types/react": "npm:^19.2.0"
     "@types/react-dom": "npm:^19.2.0"
     "@vitejs/plugin-react": "npm:^5.1.1"


### PR DESCRIPTION
## Summary

Bumps `@miden-sdk/miden-sdk` (and `@miden-sdk/react` where used) from `0.15.0` to **`0.15.1`** (the just-published patch release) and bumps the package versions in lockstep.

`0.15.1` is a patch over `0.15.0` with no API changes, so there are **no source changes** — only dependency ranges, package versions, internal workspace refs, and the scaffolder's pinned versions (plus the refreshed lockfile).

## Verification

All CI gates run locally and pass; the lockfile resolves `@miden-sdk/*@0.15.1`:

- `yarn install --immutable`
- tests
- build / typecheck

Verified against `@miden-sdk/miden-sdk@0.15.1` (now the npm `latest` tag).
