### PR TITLE
feat(guardian): expose requestGuardianInfo on the wallet adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+* Added `requestGuardianInfo(): Promise<GuardianInfo>` to the message-signer adapter surface and both React hooks (`useWallet`, `useMidenFiWallet`). It returns the connected account's guardian details (`isGuardianAccount`, `guardianEndpoint`, `guardianProvider`, `guardianSyncStatus`) for Guardian accounts, or a null/false shape otherwise.
+
 ### Fixes
 
 * `MidenWalletAdapter.requestTransaction` now dispatches by `transaction.type`: `Send` transactions go to the wallet's `requestSend` endpoint and `Consume` transactions to `requestConsume`, while `Custom` (and bare/legacy payloads) continue through the generalized `requestTransaction` endpoint. The wallet's generalized endpoint only accepts a custom-transaction payload, so consuming a note via the typed `Transaction(TransactionType.Consume, new ConsumeTransaction(...))` API previously failed with `WalletTransactionError: INVALID_PARAMS: Invalid CustomTransaction payload`. Fixes [#88](https://github.com/0xMiden/wallet-adapter/issues/88).

--- a/packages/core/base/__tests__/signer.test.ts
+++ b/packages/core/base/__tests__/signer.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import type { GuardianInfo } from '../types';
+
+describe('GuardianInfo', () => {
+  it('has the agreed shape', () => {
+    const g: GuardianInfo = {
+      isGuardianAccount: false,
+      guardianEndpoint: null,
+      guardianProvider: null,
+      guardianSyncStatus: null,
+    };
+
+    expect(Object.keys(g).sort()).toEqual([
+      'guardianEndpoint',
+      'guardianProvider',
+      'guardianSyncStatus',
+      'isGuardianAccount',
+    ]);
+  });
+});

--- a/packages/core/base/signer.ts
+++ b/packages/core/base/signer.ts
@@ -6,7 +6,7 @@ import {
   MidenSendTransaction,
   MidenTransaction,
 } from './transaction';
-import { Asset, CreateAccountParams, InputNoteDetails, SignKind, TransactionOutput } from './types';
+import { Asset, CreateAccountParams, GuardianInfo, InputNoteDetails, SignKind, TransactionOutput } from './types';
 
 export type Adapter =
   | WalletAdapter
@@ -27,6 +27,7 @@ export interface MessageSignerWalletAdapterProps<Name extends string = string>
   extends WalletAdapterProps<Name> {
   requestTransaction(transaction: MidenTransaction): Promise<string>;
   requestAssets(): Promise<Asset[]>;
+  requestGuardianInfo(): Promise<GuardianInfo>;
   requestPrivateNotes(
     noteFilterType: NoteFilterTypes,
     noteIds?: string[]
@@ -58,6 +59,7 @@ export abstract class BaseMessageSignerWalletAdapter<
   ): Promise<string>;
   abstract requestTransaction(transaction: MidenTransaction): Promise<string>;
   abstract requestAssets(): Promise<Asset[]>;
+  abstract requestGuardianInfo(): Promise<GuardianInfo>;
   abstract requestPrivateNotes(
     noteFilterType: NoteFilterTypes,
     noteIds?: string[]

--- a/packages/core/base/types.ts
+++ b/packages/core/base/types.ts
@@ -32,6 +32,18 @@ export interface Asset {
   amount: string;
 }
 
+export interface GuardianInfo {
+  isGuardianAccount: boolean;
+  guardianEndpoint: string | null;
+  guardianProvider:
+    | 'open-zeppelin'
+    | 'gateway'
+    | 'lambda-class'
+    | 'custom'
+    | null;
+  guardianSyncStatus: 'in-sync' | 'out-of-sync' | null;
+}
+
 export type InputNoteDetails = {
   noteId: string;
   senderAccountId: string | undefined;

--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -59,6 +59,7 @@ export interface WalletContextState {
 
   requestTransaction?: MessageSignerWalletAdapterProps['requestTransaction'];
   requestAssets?: MessageSignerWalletAdapterProps['requestAssets'];
+  requestGuardianInfo?: MessageSignerWalletAdapterProps['requestGuardianInfo'];
   requestPrivateNotes?: MessageSignerWalletAdapterProps['requestPrivateNotes'];
   signBytes?: MessageSignerWalletAdapterProps['signBytes'];
   importPrivateNote?: MessageSignerWalletAdapterProps['importPrivateNote'];
@@ -474,6 +475,20 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
     [adapter, handleError, connected]
   );
 
+  // Request guardian info
+  const requestGuardianInfo:
+    | MessageSignerWalletAdapterProps['requestGuardianInfo']
+    | undefined = useMemo(
+    () =>
+      adapter && 'requestGuardianInfo' in adapter
+        ? async () => {
+            if (!connected) throw handleError(new WalletNotConnectedError());
+            return await adapter.requestGuardianInfo();
+          }
+        : undefined,
+    [adapter, handleError, connected]
+  );
+
   // Request private notes
   const requestPrivateNotes:
     | MessageSignerWalletAdapterProps['requestPrivateNotes']
@@ -698,6 +713,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
       disconnect,
       requestTransaction,
       requestAssets,
+      requestGuardianInfo,
       requestPrivateNotes,
       signBytes,
       importPrivateNote,
@@ -721,6 +737,7 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
       disconnect,
       requestTransaction,
       requestAssets,
+      requestGuardianInfo,
       requestPrivateNotes,
       signBytes,
       importPrivateNote,

--- a/packages/core/react/WalletProvider.tsx
+++ b/packages/core/react/WalletProvider.tsx
@@ -321,6 +321,20 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     [adapter, handleError, connected]
   );
 
+  // Request guardian info
+  const requestGuardianInfo:
+    | MessageSignerWalletAdapterProps['requestGuardianInfo']
+    | undefined = useMemo(
+    () =>
+      adapter && 'requestGuardianInfo' in adapter
+        ? async () => {
+            if (!connected) throw handleError(new WalletNotConnectedError());
+            return await adapter.requestGuardianInfo();
+          }
+        : undefined,
+    [adapter, handleError, connected]
+  );
+
   // Request private notes
   const requestPrivateNotes:
     | MessageSignerWalletAdapterProps['requestPrivateNotes']
@@ -428,6 +442,7 @@ export const WalletProvider: FC<WalletProviderProps> = ({
         disconnect,
         requestTransaction,
         requestAssets,
+        requestGuardianInfo,
         requestPrivateNotes,
         signBytes,
         importPrivateNote,

--- a/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
+++ b/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
@@ -17,6 +17,12 @@ const createMockAdapter = (overrides = {}) => {
     disconnect: vi.fn().mockResolvedValue(undefined),
     signBytes: vi.fn().mockResolvedValue(new Uint8Array(67)),
     createAccount: vi.fn().mockResolvedValue('account-123'),
+    requestGuardianInfo: vi.fn().mockResolvedValue({
+      isGuardianAccount: false,
+      guardianEndpoint: null,
+      guardianProvider: null,
+      guardianSyncStatus: null,
+    }),
     on: vi.fn((event: string, handler: Function) => {
       if (!listeners[event]) listeners[event] = [];
       listeners[event].push(handler);
@@ -317,6 +323,16 @@ describe('MidenFiSignerProvider', () => {
       });
 
       expect(result.current.createAccount).toBeDefined();
+    });
+
+    it('exposes requestGuardianInfo from adapter', () => {
+      const { result } = renderHook(() => useMidenFiWallet(), {
+        wrapper: ({ children }) => (
+          <MidenFiSignerProvider>{children}</MidenFiSignerProvider>
+        ),
+      });
+
+      expect(typeof result.current.requestGuardianInfo).toBe('function');
     });
   });
 

--- a/packages/core/react/__tests__/useWallet.test.tsx
+++ b/packages/core/react/__tests__/useWallet.test.tsx
@@ -74,7 +74,7 @@ describe('requestGuardianInfo wiring (useWallet)', () => {
     expect(typeof result.current.requestGuardianInfo).toBe('function');
   });
 
-  it('calls through to the adapter and rejects when not connected', async () => {
+  it('rejects and does not reach the adapter when not connected', async () => {
     const stubAdapter = new StubAdapter();
     const { result } = renderHook(() => useWallet(), {
       wrapper: withWalletProvider(stubAdapter),

--- a/packages/core/react/__tests__/useWallet.test.tsx
+++ b/packages/core/react/__tests__/useWallet.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, cleanup, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+  EventEmitter,
+  WalletReadyState,
+  type Adapter,
+  type WalletAdapterEvents,
+  type WalletName,
+} from '@miden-sdk/miden-wallet-adapter-base';
+import { WalletProvider } from '../WalletProvider';
+import { useWallet } from '../useWallet';
+
+class StubAdapter extends EventEmitter<WalletAdapterEvents> {
+  name = 'Stub Wallet' as WalletName<'Stub Wallet'>;
+  url = 'https://example.com';
+  icon = 'data:image/svg+xml;base64,';
+  readyState = WalletReadyState.Installed;
+  address: string | null = null;
+  publicKey: Uint8Array | null = null;
+  connecting = false;
+  connected = false;
+  supportedTransactionVersions = null;
+
+  connect = vi.fn().mockResolvedValue(undefined);
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  requestTransaction = vi.fn().mockResolvedValue('tx-id');
+  requestAssets = vi.fn().mockResolvedValue([]);
+  requestGuardianInfo = vi.fn().mockResolvedValue({
+    isGuardianAccount: false,
+    guardianEndpoint: null,
+    guardianProvider: null,
+    guardianSyncStatus: null,
+  });
+  requestPrivateNotes = vi.fn().mockResolvedValue([]);
+  signBytes = vi.fn().mockResolvedValue(new Uint8Array());
+  importPrivateNote = vi.fn().mockResolvedValue('note-id');
+  requestConsumableNotes = vi.fn().mockResolvedValue([]);
+  waitForTransaction = vi.fn().mockResolvedValue({ txHash: '', outputNotes: [] });
+  requestSend = vi.fn().mockResolvedValue('tx-id');
+  requestConsume = vi.fn().mockResolvedValue('tx-id');
+  createAccount = vi.fn().mockResolvedValue('account-id');
+}
+
+const withWalletProvider = (adapter: Adapter) => {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <WalletProvider wallets={[adapter]}>{children}</WalletProvider>;
+  };
+};
+
+describe('requestGuardianInfo wiring (useWallet)', () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('is undefined before a wallet is selected', () => {
+    const stubAdapter = new StubAdapter();
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: withWalletProvider(stubAdapter),
+    });
+
+    expect(result.current.requestGuardianInfo).toBeUndefined();
+  });
+
+  it('exposes requestGuardianInfo through the provider once selected', async () => {
+    const stubAdapter = new StubAdapter();
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: withWalletProvider(stubAdapter),
+    });
+
+    await act(() => result.current.select(stubAdapter.name));
+
+    expect(typeof result.current.requestGuardianInfo).toBe('function');
+  });
+
+  it('calls through to the adapter and rejects when not connected', async () => {
+    const stubAdapter = new StubAdapter();
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: withWalletProvider(stubAdapter),
+    });
+
+    await act(() => result.current.select(stubAdapter.name));
+
+    await expect(result.current.requestGuardianInfo!()).rejects.toThrow();
+    expect(stubAdapter.requestGuardianInfo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/react/useWallet.ts
+++ b/packages/core/react/useWallet.ts
@@ -46,6 +46,10 @@ export interface WalletContextState {
 
   requestAssets: MessageSignerWalletAdapterProps['requestAssets'] | undefined;
 
+  requestGuardianInfo:
+    | MessageSignerWalletAdapterProps['requestGuardianInfo']
+    | undefined;
+
   requestPrivateNotes:
     | MessageSignerWalletAdapterProps['requestPrivateNotes']
     | undefined;
@@ -100,6 +104,13 @@ const DEFAULT_CONTEXT = {
     return Promise.reject(
       console.error(
         constructMissingProviderErrorMessage('get', 'requestAssets')
+      )
+    );
+  },
+  requestGuardianInfo() {
+    return Promise.reject(
+      console.error(
+        constructMissingProviderErrorMessage('get', 'requestGuardianInfo')
       )
     );
   },

--- a/packages/wallets/miden/__tests__/adapter.test.ts
+++ b/packages/wallets/miden/__tests__/adapter.test.ts
@@ -35,6 +35,14 @@ function createMockWallet(overrides: Record<string, any> = {}) {
     requestAssets: vi
       .fn()
       .mockResolvedValue({ assets: [{ faucetId: 'f1', amount: '100' }] }),
+    requestGuardianInfo: vi.fn().mockResolvedValue({
+      guardianInfo: {
+        isGuardianAccount: false,
+        guardianEndpoint: null,
+        guardianProvider: null,
+        guardianSyncStatus: null,
+      },
+    }),
     requestPrivateNotes: vi
       .fn()
       .mockResolvedValue({ privateNotes: [{ noteId: 'n1' }] }),
@@ -126,6 +134,10 @@ describe('MidenWalletAdapter', () => {
       {
         name: 'requestAssets',
         call: (a) => a.requestAssets(),
+      },
+      {
+        name: 'requestGuardianInfo',
+        call: (a) => a.requestGuardianInfo(),
       },
       {
         name: 'requestPrivateNotes',
@@ -257,6 +269,43 @@ describe('MidenWalletAdapter', () => {
       const { adapter } = await createConnectedAdapter();
       const assets = await adapter.requestAssets();
       expect(assets).toEqual([{ faucetId: 'f1', amount: '100' }]);
+    });
+
+    it('requestGuardianInfo unwraps the provider result', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      mockWallet.requestGuardianInfo.mockResolvedValue({
+        guardianInfo: {
+          isGuardianAccount: true,
+          guardianEndpoint: 'https://g',
+          guardianProvider: 'gateway',
+          guardianSyncStatus: 'in-sync',
+        },
+      });
+
+      const guardianInfo = await adapter.requestGuardianInfo();
+      expect(guardianInfo).toEqual({
+        isGuardianAccount: true,
+        guardianEndpoint: 'https://g',
+        guardianProvider: 'gateway',
+        guardianSyncStatus: 'in-sync',
+      });
+    });
+
+    it('requestGuardianInfo emits error and wraps failure', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      mockWallet.requestGuardianInfo.mockRejectedValue(
+        new Error('network error')
+      );
+
+      const errorHandler = vi.fn();
+      adapter.on('error', errorHandler);
+
+      await expect(adapter.requestGuardianInfo()).rejects.toThrow(
+        WalletTransactionError
+      );
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.any(WalletTransactionError)
+      );
     });
 
     it('requestPrivateNotes returns notes array', async () => {

--- a/packages/wallets/miden/adapter.ts
+++ b/packages/wallets/miden/adapter.ts
@@ -19,6 +19,7 @@ import {
   TransactionType,
   WalletTransactionError,
   Asset,
+  GuardianInfo,
   CreateAccountParams,
   InputNoteDetails,
   TransactionOutput,
@@ -45,6 +46,7 @@ export interface MidenWallet extends EventEmitter<MidenWalletEvents> {
     transaction: MidenTransaction
   ): Promise<{ transactionId?: string }>;
   requestAssets(): Promise<{ assets: Asset[] }>;
+  requestGuardianInfo(): Promise<{ guardianInfo: GuardianInfo }>;
   requestPrivateNotes(
     noteFilterType: NoteFilterTypes,
     noteIds?: string[]
@@ -222,6 +224,22 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
       try {
         const result = await wallet.requestAssets();
         return result.assets;
+      } catch (error: any) {
+        throw new WalletTransactionError(error?.message, error);
+      }
+    } catch (error: any) {
+      this.emit('error', error);
+      throw error;
+    }
+  }
+
+  async requestGuardianInfo(): Promise<GuardianInfo> {
+    try {
+      const wallet = this._wallet;
+      if (!wallet || !this.address) throw new WalletNotConnectedError();
+      try {
+        const result = await wallet.requestGuardianInfo();
+        return result.guardianInfo;
       } catch (error: any) {
         throw new WalletTransactionError(error?.message, error);
       }


### PR DESCRIPTION
## What this does

Adds a read-only `requestGuardianInfo(): Promise<GuardianInfo>` to the wallet-adapter surface, mirroring the existing `requestAssets` at every layer:

- `GuardianInfo` type in `@miden-sdk/miden-wallet-adapter-base` (`isGuardianAccount`, `guardianEndpoint`, `guardianProvider`, `guardianSyncStatus`).
- `requestGuardianInfo` on `MessageSignerWalletAdapterProps` + abstract `BaseMessageSignerWalletAdapter` (MessageSigner layer only — not the base adapter).
- Concrete method on `MidenWalletAdapter` (unwraps the injected `{ guardianInfo }` envelope; same try/catch → `WalletTransactionError` → `emit('error')` shape as `requestAssets`, no `watchForFailure`).
- Surfaced on **both** React hooks: `useWallet` and `useMidenFiWallet` (with the `MidenFiSignerProvider` memo deps array kept in sync).

## Cross-repo

This pairs with a companion PR on [`0xMiden/wallet`](https://github.com/0xMiden/wallet) that adds the wallet-side handler responding to the `GUARDIAN_INFO_REQUEST` wire message. The integration is the string wire protocol only (no shared-type coupling), so this PR is independently testable — but a dApp needs both landed to read guardian info end-to-end.

## Testing

- `packages/core/base` 94/94, `packages/wallets/miden` 38/38, `packages/core/react` 27/27 (Vitest).
- `tsc --noEmit` clean across all three packages.
- New tests exercise real wiring (not-connected guard, unwrap happy-path, error-emit-on-throw, and both-hooks exposure), TDD-first with independent per-task and whole-branch review.

Companion to 0xMiden/wallet#347.
