### PR TITLE
chore(release): 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.15.2 (2026-07-21)
 
 ### Features
 

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Modular TypeScript wallet adapters and React components for Miden applications.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-base",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Core infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-react",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Core react infrastructure for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-reactui",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "React UI Components for connecting Miden-compatible wallets to your dApp.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miden-sdk/miden-wallet-adapter-miden",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Miden wallet adapter for the Miden Wallet.",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release 0.15.2

Bumps all publishable packages `0.15.1 → 0.15.2` and finalizes the CHANGELOG (moves `Unreleased` → `0.15.2`).

| Package | 0.15.1 → 0.15.2 |
|---|---|
| `@miden-sdk/miden-wallet-adapter` | ✓ |
| `@miden-sdk/miden-wallet-adapter-base` | ✓ |
| `@miden-sdk/miden-wallet-adapter-react` | ✓ |
| `@miden-sdk/miden-wallet-adapter-reactui` | ✓ |
| `@miden-sdk/miden-wallet-adapter-miden` | ✓ |

### Included since 0.15.1
- **feat:** `requestGuardianInfo(): Promise<GuardianInfo>` on the message-signer surface + both React hooks (`useWallet`, `useMidenFiWallet`) — #96.
- **fix:** `requestTransaction` dispatches by `transaction.type` (`Send`→`requestSend`, `Consume`→`requestConsume`) — #88.

Version-only change: inter-package deps use `workspace:^` (resolved to real ranges at publish by `util/publish.js`), and workspace packages resolve by path in `yarn.lock`, so no lockfile change. Private example packages are intentionally not bumped.
