### PR TITLE
fix: unify WalletContext for useWallet under MidenFiSignerProvider

### DIFF
--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -34,6 +34,7 @@ import {
 import type { NoteFilterTypes, AccountComponent } from '@miden-sdk/miden-sdk';
 import { MidenWalletAdapter } from '@miden-sdk/miden-wallet-adapter-miden';
 import { useLocalStorage } from './useLocalStorage';
+import { WalletContext as CanonicalWalletContext } from './useWallet';
 
 // TYPES
 // ================================================================================================
@@ -749,11 +750,19 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
     ]
   );
 
+  // Provide BOTH the provider-local WalletContext (kept for `useMidenFiWallet`'s
+  // exact type) and the canonical WalletContext from `./useWallet` (consumed by
+  // `useWallet()` and every UI-package component: WalletMultiButton,
+  // WalletConnectButton, WalletDisconnectButton, WalletModal). Without the
+  // canonical provider those components resolve to `DEFAULT_CONTEXT` and reading
+  // e.g. `address` logs "...WalletContext without providing one" (issue #177).
   return (
     <WalletContext.Provider value={walletContextValue}>
-      <SignerContext.Provider value={signerContext}>
-        {children}
-      </SignerContext.Provider>
+      <CanonicalWalletContext.Provider value={walletContextValue as any}>
+        <SignerContext.Provider value={signerContext}>
+          {children}
+        </SignerContext.Provider>
+      </CanonicalWalletContext.Provider>
     </WalletContext.Provider>
   );
 };

--- a/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
+++ b/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
@@ -105,6 +105,7 @@ import {
   MidenFiSignerProvider,
   useMidenFiWallet,
 } from '../MidenFiSignerProvider';
+import { useWallet } from '../useWallet';
 import { MidenWalletAdapter } from '@miden-sdk/miden-wallet-adapter-miden';
 
 // Test helpers
@@ -547,6 +548,55 @@ describe('MidenFiSignerProvider', () => {
       if (capturedContext?.accountConfig) {
         expect(capturedContext.accountConfig.customComponents).toBeUndefined();
       }
+    });
+  });
+
+  describe('useWallet under MidenFiSignerProvider (issue #177)', () => {
+    it('resolves useWallet() to the provider context, not DEFAULT_CONTEXT', async () => {
+      // A connected adapter so the provider populates address in its context.
+      mockAdapter = createMockAdapter({
+        connected: true,
+        publicKey: new Uint8Array(32).fill(0x42),
+        address: '0xtest-address',
+        readyState: 'Installed',
+      });
+
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      // A UI-package-style consumer: reads `address` via useWallet().
+      const AddressConsumer = () => {
+        const { address } = useWallet();
+        return <div data-testid="address">{address ?? 'no-address'}</div>;
+      };
+
+      render(
+        <MidenFiSignerProvider>
+          <AddressConsumer />
+        </MidenFiSignerProvider>
+      );
+
+      // Let the auto-select + state sync effects settle.
+      await act(async () => {
+        await flushPromises();
+        await flushPromises();
+        await flushPromises();
+      });
+
+      // Bug: reading `address` off DEFAULT_CONTEXT logs the missing-provider error.
+      const missingProviderCalls = consoleError.mock.calls.filter((args) =>
+        args.some(
+          (a) =>
+            typeof a === 'string' && a.includes('without providing one')
+        )
+      );
+      expect(missingProviderCalls).toHaveLength(0);
+
+      // And the address flows through to the useWallet() consumer.
+      expect(screen.getByTestId('address').textContent).toBe('0xtest-address');
+
+      consoleError.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the "You have tried to read WalletContext without providing one" error thrown by `useWallet()` (and every UI-package component that consumes it — `WalletMultiButton`, `WalletConnectButton`, `WalletDisconnectButton`, `WalletModal`) when rendered under `MidenFiSignerProvider`.

## Root cause

There were two distinct React contexts named `WalletContext`:

- `MidenFiSignerProvider.tsx` creates and provides its **own** `WalletContext` (`createContext<WalletContextState>({} as WalletContextState)`).
- `useWallet()` in `useWallet.ts` reads a **separate** `WalletContext` initialised with `DEFAULT_CONTEXT`.

Because the provider only supplied the first context, any component calling `useWallet()` under `MidenFiSignerProvider` resolved to `DEFAULT_CONTEXT`, whose `address`/`wallet`/`wallets`/`publicKey` getters log the missing-provider error and return null. `useMidenFiWallet()` worked only because it happens to read the provider-local context.

## Fix

Additive and backward-compatible. `MidenFiSignerProvider` now also renders the canonical `WalletContext` from `./useWallet`, nested inside the existing provider-local one, sharing the same `walletContextValue`:

```tsx
<WalletContext.Provider value={walletContextValue}>
  <CanonicalWalletContext.Provider value={walletContextValue as any}>
    <SignerContext.Provider value={signerContext}>
      {children}
    </SignerContext.Provider>
  </CanonicalWalletContext.Provider>
</WalletContext.Provider>
```

- The provider-local context is kept, so `useMidenFiWallet()`'s type is unchanged.
- The public `WalletContext` export (via `index.ts`) is unchanged — no breaking change for external consumers.
- The `as any` cast bridges the two slightly-different `WalletContextState` interfaces without a type refactor.

## Testing

- Added a TDD test in `packages/core/react/__tests__/MidenFiSignerProvider.test.tsx` that renders `<MidenFiSignerProvider>` around a component calling `useWallet()` and reading `address`, asserting no missing-provider `console.error` and that the address flows through.
- Adversarial RED→GREEN verified: reverting only the source fix makes the new test fail with the exact missing-provider error; restoring it passes.
- Full package suite green: 28 tests pass (25 in `MidenFiSignerProvider.test.tsx` incl. the new one, 3 in `useWallet.test.tsx`).
- `tsc --noEmit` clean; no new type errors.

Closes 0xMiden/wallet#177

Note: this PR lives in `0xMiden/wallet-adapter` while the issue is filed in `0xMiden/wallet`. GitHub's cross-repo `Closes` reference may not auto-close on merge, so a maintainer may need to close the issue manually.
