### PR TITLE
Update SendComponent to use requestSend method

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Access wallet state and functionality with the `useWallet` hook:
 import { useWallet, SendTransaction } from '@miden-sdk/miden-wallet-adapter';
 
 function SendComponent() {
-  const { wallet, address, connected } = useWallet();
+  const { wallet, address, connected, requestSend } = useWallet();
 
   const handleSend = async () => {
-    if (!wallet || !address) return;
+    if (!wallet || !address || !requestSend) return;
 
     const transaction = new SendTransaction(
       address,
@@ -77,7 +77,7 @@ function SendComponent() {
     );
 
     try {
-      await wallet.adapter.requestSend(transaction);
+      await requestSend(transaction);
       console.log('Transaction sent successfully!');
     } catch (error) {
       console.error('Transaction failed:', error);


### PR DESCRIPTION
Fixes the README Send Transaction example, which currently calls wallet.adapter.requestSend(...) — this fails to type-check because Adapter is a union type (WalletAdapter | SignerWalletAdapter | MessageSignerWalletAdapter) and requestSend only exists on MessageSignerWalletAdapter. The useWallet() hook already exposes requestSend directly with the correct type, matching the pattern already used for requestTransaction in the Custom Transaction example below.

Related: 0xMiden/feedback#93.