### PR TITLE
fix: use top-level requestSend from useWallet() instead of wallet.adapter cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Access wallet state and functionality with the `useWallet` hook:
 import { useWallet, SendTransaction } from '@miden-sdk/miden-wallet-adapter';
 
 function SendComponent() {
-  const { wallet, address, connected } = useWallet();
+  const { wallet, address, connected, requestSend } = useWallet();
 
   const handleSend = async () => {
-    if (!wallet || !address) return;
+    if (!wallet || !address || !requestSend) return;
 
     const transaction = new SendTransaction(
       address,
@@ -77,7 +77,7 @@ function SendComponent() {
     );
 
     try {
-      await wallet.adapter.requestSend(transaction);
+      await requestSend(transaction);
       console.log('Transaction sent successfully!');
     } catch (error) {
       console.error('Transaction failed:', error);

--- a/packages/all/README.md
+++ b/packages/all/README.md
@@ -84,10 +84,10 @@ Access wallet state and functionality with the `useWallet` hook:
 import { useWallet, SendTransaction } from '@miden-sdk/miden-wallet-adapter';
 
 function SendComponent() {
-  const { wallet, address, connected } = useWallet();
+  const { wallet, address, connected, requestSend } = useWallet();
 
   const handleSend = async () => {
-    if (!wallet || !address) return;
+    if (!wallet || !address || !requestSend) return;
 
     const transaction = new SendTransaction(
       address,
@@ -98,7 +98,7 @@ function SendComponent() {
     );
 
     try {
-      await wallet.adapter.requestSend(transaction);
+      await requestSend(transaction);
       console.log('Transaction sent successfully!');
     } catch (error) {
       console.error('Transaction failed:', error);


### PR DESCRIPTION
## Problem

The `SendComponent` example in the README (and in `packages/all/README.md`,
which is what actually ships to npm) calls `wallet.adapter.requestSend(...)`.

`wallet.adapter` is typed as the shared `Adapter` union
(`WalletAdapter | SignerWalletAdapter | MessageSignerWalletAdapter`), and
TypeScript only allows calling methods present on *every* member of a union
— so `requestSend`, which only exists on `MessageSignerWalletAdapter`, can't
be called on `wallet.adapter` without an unsafe cast.

Meanwhile the `CustomTransaction` example right below it already uses the
correct, properly-typed API: `useWallet()` exposes `requestSend` at the top
level (see `useWallet.ts`), delegating to the adapter internally. The two
examples were just inconsistent — one shows the safe pattern, the other
doesn't.

## Fix

Updates both `SendComponent` examples (root `README.md` and
`packages/all/README.md`) to destructure `requestSend` from `useWallet()`
directly, matching the pattern already used by the `CustomTransaction`
example. No behavior change — just removes the need for a cast that
shouldn't have been necessary in the first place.