### PR TITLE
fix: update package repository metadata

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -42,6 +42,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "https://github.com/0xMiden/wallet-adapter.git"
   }
 }

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "https://github.com/0xMiden/wallet-adapter.git"
   },
   "author": "Demox Labs",
   "license": "MIT",

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "https://github.com/0xMiden/wallet-adapter.git"
   },
   "author": "Demox Labs",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "https://github.com/0xMiden/wallet-adapter.git"
   },
   "author": "Demox Labs",
   "license": "MIT",

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "https://github.com/0xMiden/wallet-adapter.git"
   },
   "author": "Demox Labs",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Updates package `repository.url` metadata to point at the active `0xMiden/wallet-adapter` repository.

Fixes #103.

## Why

The published package manifests still referenced the old `demox-labs/miden-wallet-adapter` repository. That metadata can send npm users to the wrong source repository when they inspect package details.

## Changes

Updated repository URLs in:

- `packages/all/package.json`
- `packages/core/base/package.json`
- `packages/core/react/package.json`
- `packages/ui/package.json`
- `packages/wallets/miden/package.json`

## Testing

- `git diff --check`
- Parsed the edited package manifests with `ConvertFrom-Json`