### PR TITLE
fix: re-drive connect() when already connected so dApp reconnect repopulates the account (wallet#470)

### DIFF
--- a/packages/core/react/MidenFiSignerProvider.tsx
+++ b/packages/core/react/MidenFiSignerProvider.tsx
@@ -387,7 +387,13 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
 
   // Connect the adapter to the wallet
   const connect = useCallback(async () => {
-    if (isConnecting.current || isDisconnecting.current || connected) return;
+    // Do NOT early-return when already `connected`. The in-app wallet
+    // browser preserves a dApp's JS context across a park/restore, so a
+    // re-opened dApp is still `connected` — a repeat connect() must re-drive
+    // the adapter so the account is repopulated ("Connect Wallet works only
+    // once", 0xMiden/wallet#470). Concurrency is covered by the
+    // `isConnecting` ref here and the adapter's own in-flight guard.
+    if (isConnecting.current || isDisconnecting.current) return;
     if (!adapter) throw handleError(new WalletNotSelectedError());
 
     if (
@@ -410,7 +416,10 @@ export const MidenFiSignerProvider: FC<MidenFiSignerProviderProps> = ({
     try {
       await adapter.connect(privateDataPermission, network, allowedPrivateData);
     } catch (error: any) {
-      setName(null);
+      // Preserve a still-live session: a re-drive that fails while the
+      // adapter is still connected (e.g. wallet locked and the unlock prompt
+      // was dismissed) must not tear down the selected wallet (#470).
+      if (!adapter.connected) setName(null);
       throw error;
     } finally {
       setConnecting(false);

--- a/packages/core/react/WalletProvider.tsx
+++ b/packages/core/react/WalletProvider.tsx
@@ -147,15 +147,26 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     return () => window.removeEventListener('beforeunload', listener);
   }, [isUnloading]);
 
-  // Handle the adapter's connect event
+  // Handle the adapter's connect event.
+  // Functional update bails out when values haven't changed so a repeat
+  // `connect` emit (e.g. re-driving an already-connected adapter, #470)
+  // doesn't force a redundant re-render.
   const handleConnect = useCallback(() => {
     if (!adapter) return;
-    setState((state) => ({
-      ...state,
-      connected: adapter.connected,
-      address: adapter.address,
-      publicKey: adapter.publicKey,
-    }));
+    setState((state) => {
+      if (
+        state.connected === adapter.connected &&
+        state.address === adapter.address &&
+        state.publicKey === adapter.publicKey
+      )
+        return state;
+      return {
+        ...state,
+        connected: adapter.connected,
+        address: adapter.address,
+        publicKey: adapter.publicKey,
+      };
+    });
   }, [adapter]);
 
   // Handle the adapter's disconnect event
@@ -231,7 +242,13 @@ export const WalletProvider: FC<WalletProviderProps> = ({
 
   // Connect the adapter to the wallet
   const connect = useCallback(async () => {
-    if (isConnecting.current || isDisconnecting.current || connected) return;
+    // Do NOT early-return when already `connected`. The in-app wallet
+    // browser preserves a dApp's JS context across a park/restore, so a
+    // re-opened dApp is still `connected` — a repeat connect() must re-drive
+    // the adapter so the account is repopulated ("Connect Wallet works only
+    // once", 0xMiden/wallet#470). Concurrency is covered by the
+    // `isConnecting` ref here and the adapter's own in-flight guard.
+    if (isConnecting.current || isDisconnecting.current) return;
     if (!adapter) throw handleError(new WalletNotSelectedError());
 
     if (
@@ -255,8 +272,10 @@ export const WalletProvider: FC<WalletProviderProps> = ({
     try {
       await adapter.connect(privateDataPermission, network, allowedPrivateData);
     } catch (error: any) {
-      // Clear the selected wallet
-      setName(null);
+      // Preserve a still-live session: a re-drive that fails while the
+      // adapter is still connected (e.g. wallet locked and the unlock prompt
+      // was dismissed) must not tear down the selected wallet (#470).
+      if (!adapter.connected) setName(null);
       // Rethrow the error, and handleError will also be called
       throw error;
     } finally {

--- a/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
+++ b/packages/core/react/__tests__/MidenFiSignerProvider.test.tsx
@@ -378,6 +378,44 @@ describe('MidenFiSignerProvider', () => {
 
       expect(typeof capturedContext.disconnect).toBe('function');
     });
+
+    it('re-drives adapter.connect() when connect() is called again while already connected (0xMiden/wallet#470)', async () => {
+      // The in-app browser preserves a dApp's JS context across a
+      // park/restore, so the provider can be `connected` when the user taps
+      // Connect again. A second connect() must re-drive the adapter (which
+      // repopulates the current account) instead of silently no-opping.
+      mockAdapter = createMockAdapter({
+        readyState: 'Installed',
+        connect: vi.fn().mockImplementation(async () => {
+          mockAdapter.connected = true;
+          mockAdapter.address = '0xabc';
+          mockAdapter.publicKey = new Uint8Array([1, 2, 3]);
+          mockAdapter.emit('connect', '0xabc');
+        }),
+      });
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <MidenFiSignerProvider>{children}</MidenFiSignerProvider>
+      );
+      const { result } = renderHook(() => useMidenFiWallet(), { wrapper });
+
+      // Let the provider mount + auto-select the single default wallet.
+      await act(async () => {
+        await flushPromises();
+        await flushPromises();
+      });
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(mockAdapter.connect).toHaveBeenCalledTimes(1);
+      expect(result.current.connected).toBe(true);
+
+      await act(async () => {
+        await result.current.connect();
+      });
+      expect(mockAdapter.connect).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('accountConfig', () => {

--- a/packages/core/react/__tests__/useWallet.test.tsx
+++ b/packages/core/react/__tests__/useWallet.test.tsx
@@ -86,3 +86,42 @@ describe('requestGuardianInfo wiring (useWallet)', () => {
     expect(stubAdapter.requestGuardianInfo).not.toHaveBeenCalled();
   });
 });
+
+describe('connect re-drive when already connected (useWallet, 0xMiden/wallet#470)', () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it('re-drives adapter.connect() when connect() is called again while already connected', async () => {
+    const stubAdapter = new StubAdapter();
+    // A successful connect flips the adapter to connected and emits `connect`,
+    // so the provider transitions to connected (mirrors a real handshake).
+    stubAdapter.connect = vi.fn().mockImplementation(async () => {
+      stubAdapter.connected = true;
+      stubAdapter.address = '0xabc';
+      stubAdapter.publicKey = new Uint8Array([1, 2, 3]);
+      stubAdapter.emit('connect', '0xabc');
+    });
+
+    const { result } = renderHook(() => useWallet(), {
+      wrapper: withWalletProvider(stubAdapter),
+    });
+
+    await act(() => result.current.select(stubAdapter.name));
+
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(stubAdapter.connect).toHaveBeenCalledTimes(1);
+    expect(result.current.connected).toBe(true);
+
+    // The in-app browser preserves the dApp's JS context across a
+    // park/restore, so a re-opened dApp is still connected. A second
+    // connect() must re-drive instead of silently no-opping (#470).
+    await act(async () => {
+      await result.current.connect();
+    });
+    expect(stubAdapter.connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/wallets/miden/__tests__/adapter.test.ts
+++ b/packages/wallets/miden/__tests__/adapter.test.ts
@@ -443,15 +443,60 @@ describe('MidenWalletAdapter', () => {
       ).rejects.toThrow(WalletConnectionError);
     });
 
-    it('does nothing if already connected', async () => {
+    it('re-drives the handshake and re-emits `connect` when called while already connected, repopulating the current account (0xMiden/wallet#470)', async () => {
       const { adapter, mockWallet } = await createConnectedAdapter();
-      // Call connect again
+
+      const connectHandler = vi.fn();
+      adapter.on('connect', connectHandler);
+
+      // The in-app browser preserves this adapter's JS context across a
+      // park/restore, so a re-opened dApp finds `connected === true`. The
+      // old early-return made a second connect() a silent no-op, so a
+      // re-mounted consumer that re-subscribed to events never got its
+      // account back ("Connect Wallet works only once"). A repeat connect()
+      // must re-drive the wallet handshake — which returns the current
+      // account — and re-emit `connect` so the consumer repopulates.
       await adapter.connect(
         PrivateDataPermission.UponRequest,
         WalletAdapterNetwork.Testnet
       );
-      // wallet.connect should have been called only once (during initial connect)
+
+      expect(mockWallet.connect).toHaveBeenCalledTimes(2);
+      expect(connectHandler).toHaveBeenCalledWith('0xmockaddress');
+      expect(adapter.connected).toBe(true);
+      expect(adapter.address).toBe('0xmockaddress');
+    });
+
+    it('ignores a concurrent connect() while one is still in flight', async () => {
+      let releaseFirstConnect: () => void = () => {};
+      const mockWallet = createMockWallet({
+        connect: vi.fn(
+          () =>
+            new Promise<void>(resolve => {
+              releaseFirstConnect = resolve;
+            })
+        ),
+      });
+      (window as any).midenWallet = mockWallet;
+
+      const adapter = new MidenWalletAdapter();
+      adapter.readyState = WalletReadyState.Installed;
+
+      // First connect stays in flight (its wallet.connect() promise is pending).
+      const first = adapter.connect(
+        PrivateDataPermission.UponRequest,
+        WalletAdapterNetwork.Testnet
+      );
+      // A second call while `connecting` is true must be a guarded no-op.
+      await adapter.connect(
+        PrivateDataPermission.UponRequest,
+        WalletAdapterNetwork.Testnet
+      );
       expect(mockWallet.connect).toHaveBeenCalledTimes(1);
+
+      releaseFirstConnect();
+      await first;
+      expect(adapter.connected).toBe(true);
     });
   });
 

--- a/packages/wallets/miden/adapter.ts
+++ b/packages/wallets/miden/adapter.ts
@@ -358,7 +358,23 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
     allowedPrivateData?: AllowedPrivateData
   ): Promise<void> {
     try {
-      if (this.connected || this.connecting) return;
+      // Guard only against a *concurrent* connect — NOT against being
+      // already connected. The in-app wallet browser preserves this
+      // adapter's JS context across a park/restore (a dApp is minimized and
+      // reopened without a page reload), so a re-opened dApp finds this
+      // instance with `connected === true`. An early-return-when-connected
+      // made a second connect() a silent no-op, so a re-mounted consumer
+      // that re-subscribed to events never received its account back —
+      // "Connect Wallet works only once" (0xMiden/wallet#470). Re-driving
+      // the handshake below is cheap for the common case — the wallet
+      // returns the current account for an existing permission without
+      // re-prompting — and re-emits `connect`, so repeated connect() calls
+      // repopulate the account instead of being suppressed by stale session
+      // state. (If the wallet has since locked, the re-drive can surface an
+      // unlock prompt where the old code was a silent no-op; that's the
+      // intended trade-off — a locked wallet genuinely needs to be unlocked
+      // to hand back the account.)
+      if (this.connecting) return;
       if (this._readyState !== WalletReadyState.Installed)
         throw new WalletNotReadyError();
 


### PR DESCRIPTION
Addresses **0xMiden/wallet#470** (adapter-side root cause).

## Problem

The in-wallet dApp browser opens a faucet; **Connect works the first time, but a second attempt does nothing** — on Android the connect popup stops opening, on iOS the account is no longer populated.

Root cause (adapter side): the in-app browser preserves a dApp's JS context across a **park/restore** (a dApp is minimized and reopened *without* a page reload — the wallet's `DappBrowserProvider` explicitly keeps sessions "with their JS context preserved across park/restore"). So the `MidenWalletAdapter` instance — and the `MidenFiSignerProvider` / `WalletProvider` React state — survive with `connected === true`. Every `connect()` layer then early-returned:

- `MidenWalletAdapter.connect()` → `if (this.connected || this.connecting) return;`
- `MidenFiSignerProvider` / `WalletProvider` `connect()` wrappers → `if (… || connected) return;`

so a second "Connect Wallet" is a **silent no-op** and the account is never handed back to a re-mounted / re-subscribed consumer. The injected `window.midenWallet.connect()` itself has no such guard and, for an already-granted permission with the wallet unlocked, the wallet returns the **current** account without re-prompting.

## Change

Drop the `connected` check from the connect guard at **every** consumer layer so a repeat `connect()` re-drives the handshake (which repopulates the current account) and re-emits `connect`. Concurrency is still guarded by the adapter's own in-flight check and the providers' `isConnecting` ref.

- **`packages/wallets/miden/adapter.ts`** — guard on `connecting` only; a repeat connect re-drives + re-emits.
- **`packages/core/react/MidenFiSignerProvider.tsx` / `WalletProvider.tsx`** — same. A re-drive that *fails* while the adapter is still connected (e.g. wallet locked, unlock dismissed) no longer tears down the selected wallet (`setName(null)` only when actually disconnected). `WalletProvider.handleConnect` made idempotent so a redundant `connect` emit doesn't force a re-render (matching the existing `MidenFiSignerProvider` behavior).

## Tests

- `adapter.test.ts` — repeat `connect()` re-drives + re-emits `connect`; a concurrent `connect()` is still a guarded no-op (in-flight).
- `MidenFiSignerProvider.test.tsx` / `useWallet.test.tsx` — `connect()` via the public hooks re-drives when already connected (verified **non-vacuous**: reverting the guard fails the test).

All suites green (`yarn test`: base 94, react 29, miden 39) + `tsc --noEmit` clean on the changed packages.

## Note

This fixes the **adapter / consumer-side** reconnect path, which is what the faucet drives. The wallet's native park/restore lifecycle is unchanged (and correct — it deliberately preserves the JS context); the bug was the adapter suppressing the reconnect the restored dApp needs. I couldn't reproduce end-to-end on the iOS simulator (fresh un-onboarded build, no scriptable input), so the on-device symptom should be re-verified before closing wallet#470.
