### PR TITLE
fix: reject requestSend/Consume/Transaction when the wallet returns no transaction id (wallet#314)

### DIFF
--- a/packages/wallets/miden/__tests__/adapter.test.ts
+++ b/packages/wallets/miden/__tests__/adapter.test.ts
@@ -207,6 +207,45 @@ describe('MidenWalletAdapter', () => {
       expect(result).toBe('tx-consume-1');
     });
 
+    it('requestSend rejects (does not resolve undefined) when the wallet returns no transactionId (0xMiden/wallet#314)', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      // The wallet resolved "successfully" but without a transaction id — meaning
+      // the transaction was never submitted; the dApp must see a rejection.
+      mockWallet.requestSend.mockResolvedValue({});
+      const errorHandler = vi.fn();
+      adapter.on('error', errorHandler);
+
+      await expect(
+        adapter.requestSend({
+          senderAddress: 's',
+          recipientAddress: 'r',
+          faucetId: 'f',
+          noteType: 'public' as const,
+          amount: 1,
+        })
+      ).rejects.toThrow(WalletTransactionError);
+      expect(errorHandler).toHaveBeenCalled();
+    });
+
+    it('requestConsume rejects when the wallet returns no transactionId (0xMiden/wallet#314)', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      mockWallet.requestConsume.mockResolvedValue({ transactionId: undefined });
+
+      await expect(
+        adapter.requestConsume({ faucetId: 'f', noteId: 'n', noteType: 'public' as const, amount: 1 })
+      ).rejects.toThrow(WalletTransactionError);
+    });
+
+    it('requestTransaction (custom) rejects when the wallet returns no transactionId (0xMiden/wallet#314)', async () => {
+      const { adapter, mockWallet } = await createConnectedAdapter();
+      mockWallet.requestTransaction.mockResolvedValue({});
+
+      await expect(
+        adapter.requestTransaction({ type: 'custom' as any, payload: {} as any })
+      ).rejects.toThrow(WalletTransactionError);
+      expect(mockWallet.requestTransaction).toHaveBeenCalled();
+    });
+
     it('requestTransaction routes a Consume transaction to wallet.requestConsume (issue #88)', async () => {
       const { adapter, mockWallet } = await createConnectedAdapter();
       const payload = {

--- a/packages/wallets/miden/adapter.ts
+++ b/packages/wallets/miden/adapter.ts
@@ -146,16 +146,34 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
     this._readyState = readyState;
   }
 
+  /**
+   * The wallet reports "success" as soon as a transaction is ACCEPTED into its
+   * queue, not when it lands on chain — so a resolved call with no `transactionId`
+   * means the transaction was never submitted. Returning that as `undefined`
+   * (the old `result.transactionId!` non-null assertion) made the dApp treat a
+   * silent drop as success. Reject instead, so the dApp can surface it and
+   * poll `waitForTransaction(txId)` for on-chain confirmation (0xMiden/wallet#314).
+   */
+  private requireTransactionId(result: { transactionId?: string }): string {
+    if (!result?.transactionId) {
+      throw new WalletTransactionError(
+        'The wallet returned no transaction id — the transaction was not submitted'
+      );
+    }
+    return result.transactionId;
+  }
+
   async requestSend(transaction: MidenSendTransaction): Promise<string> {
     try {
       const wallet = this._wallet;
       if (!wallet || !this.address) throw new WalletNotConnectedError();
+      let result: { transactionId?: string };
       try {
-        const result = await wallet.requestSend(transaction);
-        return result.transactionId!;
+        result = await wallet.requestSend(transaction);
       } catch (error: any) {
         throw new WalletTransactionError(error?.message, error);
       }
+      return this.requireTransactionId(result);
     } catch (error: any) {
       this.emit('error', error);
       throw error;
@@ -166,12 +184,13 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
     try {
       const wallet = this._wallet;
       if (!wallet || !this.address) throw new WalletNotConnectedError();
+      let result: { transactionId?: string };
       try {
-        const result = await wallet.requestConsume(transaction);
-        return result.transactionId!;
+        result = await wallet.requestConsume(transaction);
       } catch (error: any) {
         throw new WalletTransactionError(error?.message, error);
       }
+      return this.requireTransactionId(result);
     } catch (error: any) {
       this.emit('error', error);
       throw error;
@@ -182,6 +201,7 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
     try {
       const wallet = this._wallet;
       if (!wallet || !this.address) throw new WalletNotConnectedError();
+      let result: { transactionId?: string };
       try {
         // The wallet's generalized `requestTransaction` endpoint only accepts
         // a custom-transaction payload, so a `send`/`consume` transaction must
@@ -189,7 +209,6 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
         // it with "Invalid CustomTransaction payload". Dispatching by `type`
         // here is what lets the typed `Transaction` / `TransactionType` API
         // (incl. `Transaction.createConsumeTransaction`) work for every type.
-        let result: { transactionId?: string };
         switch (transaction.type) {
           case TransactionType.Send:
             result = await wallet.requestSend(
@@ -207,10 +226,10 @@ export class MidenWalletAdapter extends BaseMessageSignerWalletAdapter {
             result = await wallet.requestTransaction(transaction);
             break;
         }
-        return result.transactionId!;
       } catch (error: any) {
         throw new WalletTransactionError(error?.message, error);
       }
+      return this.requireTransactionId(result);
     } catch (error: any) {
       this.emit('error', error);
       throw error;


### PR DESCRIPTION
Addresses **0xMiden/wallet#314** (the adapter-side half).

## Problem

A custom transaction with an output note, sent via `requestTransaction`, resolves "success" in the dApp but never reaches the chain. Root cause (confirmed from the wallet code): the wallet reports success as soon as a tx is **accepted into its queue**, not when it's submitted — the returned id is a queue UUID, and the real execute→prove→submit runs asynchronously; a failure there is only logged. The **adapter** then compounded it: `return result.transactionId!` turned a `{}`/`{transactionId: undefined}` response into a silently-resolved `undefined` the dApp reads as success.

## Change

Guard `requestSend` / `requestConsume` / `requestTransaction` with `requireTransactionId`: **reject** with `WalletTransactionError` (and `emit('error')`) when the wallet returns no id, instead of resolving `undefined`. Restructured so the guard runs *outside* the wallet-call try/catch (no double-wrap). So a dropped/never-submitted transaction now surfaces as a rejection the dApp can handle, and it can poll `waitForTransaction(txId)` for on-chain confirmation.

## Tests

`requestSend`/`requestConsume`/`requestTransaction(custom)` each reject with `WalletTransactionError` when the wallet returns no transaction id (RED→GREEN); the happy path (id present) still resolves it. Full suite green (`yarn test`: base 94, react 30, miden 42), tsc + lint clean.

## Remaining (out of scope here)

This fixes the adapter's silent-`undefined` footgun. The deeper "success is reported at **enqueue**, not **submission**" behavior lives in the wallet extension — closing #314 fully means the extension either awaits terminal state before resolving `requestTransaction`, or the contract stays "returns a queue id, dApp polls `waitForTransaction`" (a maintainer design call). The one deterministic custom-tx failure the reporter saw (no popup, `transactionId: undefined`, 3/3) is specific to the 2026-07-03 release and isn't reproducible from current `main`; confirming it needs a live testnet run of a current build against the reporter's harness.
