### PR TITLE
chore: correct package metadata and declare the miden-sdk peer dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Demox Labs
+Copyright (c) 2026 Miden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -42,6 +42,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "git+https://github.com/0xMiden/wallet-adapter.git",
+    "directory": "packages/all"
+  },
+  "bugs": {
+    "url": "https://github.com/0xMiden/wallet-adapter/issues"
   }
 }

--- a/packages/core/base/package.json
+++ b/packages/core/base/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "git+https://github.com/0xMiden/wallet-adapter.git",
+    "directory": "packages/core/base"
   },
   "author": "Demox Labs",
   "license": "MIT",
@@ -20,7 +21,14 @@
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "jsdom": "^24.0.0",
     "vitest": "^1.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/0xMiden/wallet-adapter/issues"
+  },
+  "peerDependencies": {
+    "@miden-sdk/miden-sdk": "^0.15.1"
   }
 }

--- a/packages/core/react/package.json
+++ b/packages/core/react/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "git+https://github.com/0xMiden/wallet-adapter.git",
+    "directory": "packages/core/react"
   },
   "author": "Demox Labs",
   "license": "MIT",
@@ -38,5 +39,8 @@
     "@miden-sdk/react": {
       "optional": true
     }
+  },
+  "bugs": {
+    "url": "https://github.com/0xMiden/wallet-adapter/issues"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "git+https://github.com/0xMiden/wallet-adapter.git",
+    "directory": "packages/ui"
   },
   "author": "Demox Labs",
   "license": "MIT",
@@ -32,5 +33,8 @@
     "@types/react-dom": "^19.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
+  },
+  "bugs": {
+    "url": "https://github.com/0xMiden/wallet-adapter/issues"
   }
 }

--- a/packages/wallets/miden/package.json
+++ b/packages/wallets/miden/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/demox-labs/miden-wallet-adapter.git"
+    "url": "git+https://github.com/0xMiden/wallet-adapter.git",
+    "directory": "packages/wallets/miden"
   },
   "author": "Demox Labs",
   "license": "MIT",
@@ -21,10 +22,15 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "jsdom": "^24.0.0",
     "vitest": "^1.0.0"
   },
   "peerDependencies": {
+    "@miden-sdk/miden-sdk": "^0.15.1",
     "typescript": "^5.0.0"
+  },
+  "bugs": {
+    "url": "https://github.com/0xMiden/wallet-adapter/issues"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -756,9 +756,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miden-sdk/miden-wallet-adapter-base@workspace:packages/core/base"
   dependencies:
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     eventemitter3: "npm:^5.0.1"
     jsdom: "npm:^24.0.0"
     vitest: "npm:^1.0.0"
+  peerDependencies:
+    "@miden-sdk/miden-sdk": ^0.15.1
   languageName: unknown
   linkType: soft
 
@@ -766,11 +769,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@miden-sdk/miden-wallet-adapter-miden@workspace:packages/wallets/miden"
   dependencies:
+    "@miden-sdk/miden-sdk": "npm:^0.15.1"
     "@miden-sdk/miden-wallet-adapter-base": "workspace:^"
     jsdom: "npm:^24.0.0"
     nanoid: "npm:^5.0.9"
     vitest: "npm:^1.0.0"
   peerDependencies:
+    "@miden-sdk/miden-sdk": ^0.15.1
     typescript: ^5.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Preparation for moving these packages into `0xMiden/web-sdk`. Each item is a defect today, independent of the move — fixing them here keeps the eventual import PR reviewable as a pure move.

- **`repository.url` pointed at `demox-labs/miden-wallet-adapter`** on all five packages. npm rejects `--provenance` when it does not match the publishing repository, so this blocks trusted publishing wherever these end up. Now `0xMiden/wallet-adapter` with a `directory` field.
- **`-base` and `-miden` used `@miden-sdk/miden-sdk` without declaring it.** They resolve today only because the repo sets `nodeLinker: node-modules`; pnpm's isolated store breaks them on contact. Declared as a peer + `devDependency`, matching how `core/react` already handles `@miden-sdk/react`.
- **No `LICENSE` file existed**, while all five packages declare `"license": "MIT"`. Added, preserving the original Demox Labs copyright alongside Miden's.

166 tests pass unchanged (base 94, react 30, miden 42).

<details>
<summary>Why peer rather than a plain dependency</summary>

`packages/core/base` imports the SDK three times, all `import type` — so it needs it only to build. `packages/wallets/miden/adapter.ts` imports `Note` as a *value*, so it has a genuine runtime dependency.

Both get a peer dependency rather than a direct one: two copies of the WASM SDK in one install graph is a known failure mode (the same class as the duplicate-Dexie problem), and a peer lets the consumer pin the single copy. `packages/ui` and `packages/all` do **not** import the SDK at all, so they deliberately do not declare it — adding it there to satisfy a lint or sync gate would write a false dependency.
</details>

**Reviewers:** the peer-dependency range (`^0.15.1`) is the part worth checking — it mirrors `core/react`, but if these packages should track the SDK more loosely, say so now rather than after the move.
